### PR TITLE
ci: add HOL skill validation workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,37 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - skills/route/**
+      - .github/workflows/hol-skill-validate.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - skills/route/**
+      - .github/workflows/hol-skill-validate.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    concurrency:
+      group: hol-skill-validate-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate skill package
+        uses: hashgraph-online/skill-publish@df6ae95e010d9792158a441eec9ac50d4d17139d
+        with:
+          mode: validate
+          skill-dir: skills/route
+          annotate: "false"
+          preview-upload: "false"


### PR DESCRIPTION
Adds a validate-only HOL skill workflow for the existing `skills/route` package.

This version fixes the blockers from PR #3:
- passes `skill-dir: skills/route`
- keeps PR validation fork-safe by not requesting `id-token: write`
- disables preview upload in validate-only mode
- scopes runs to the skill path and workflow file

No runtime code changes.