### PR TITLE
fix: install agno extra in CI and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra agno
 
       - name: Lint
         run: uv run ruff check src/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra agno
 
       - name: Lint
         run: uv run ruff check src/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v2.0.2 — Fix release CI for Agno tests (2026-04-07)
+
+### Fixed
+
+- **Release and CI test jobs now install the `agno` extra** (`.github/workflows/ci.yml`, `.github/workflows/publish.yml`)
+
+  The workflows were running the full test suite, including `tests/test_agno_integration.py`, but only installing `--extra dev`. That made both CI and tag-based publish fail before release because `agno` was missing. Both workflows now install `uv sync --extra dev --extra agno` before running tests.
+
 ## v2.0.1 — Harder Claude Code routing enforcement (2026-04-07)
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-code-llm-router"
-version = "2.0.1"
+version = "2.0.2"
 description = "Multi-LLM router MCP server for Claude Code — smart complexity routing, Claude subscription monitoring, Codex integration, 20+ providers"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -346,7 +346,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-llm-router"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- bump package metadata to `2.0.2` for the release CI fix
- install `--extra agno` in CI and publish test jobs so the full test suite matches the dependencies it exercises
- document the fix in the changelog

## Verification
- `uv sync --extra dev --extra agno && uv run pytest tests/ -q --ignore=tests/test_integration.py --timeout=30`
- `uv lock --check`
- `uv run ruff check src/`