### PR TITLE
chore: enforce release hygiene

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "llm-router",
       "description": "Route text, image, video, and audio tasks to 20+ AI providers with smart routing, budget control, and multi-step orchestration",
-      "version": "1.1.0",
+      "version": "2.2.0",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,4 +65,34 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
-          skip_existing: true
+          skip-existing: true
+
+  github_release:
+    name: Sync GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract release notes from CHANGELOG
+        env:
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          TAG="${TAG_REF#v}"
+          python3 scripts/release_guard.py title --version "$TAG" > "$RUNNER_TEMP/release-title.txt"
+          python3 scripts/release_guard.py notes --version "$TAG" --output "$RUNNER_TEMP/release-notes.md"
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          TITLE="$(cat "$RUNNER_TEMP/release-title.txt")"
+          if gh release view "$TAG_REF" >/dev/null 2>&1; then
+            gh release edit "$TAG_REF" --title "$TITLE" --notes-file "$RUNNER_TEMP/release-notes.md"
+          else
+            gh release create "$TAG_REF" --title "$TITLE" --notes-file "$RUNNER_TEMP/release-notes.md"
+          fi

--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -1,0 +1,45 @@
+name: Release Hygiene
+
+on:
+  push:
+    branches:
+      - "**"
+    tags-ignore:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  release-hygiene:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify release metadata stays in sync
+        run: python3 scripts/release_guard.py sync
+
+      - name: Fetch base ref for pull request
+        if: github.event_name == 'pull_request'
+        run: git fetch origin "${{ github.base_ref }}" --depth=1
+
+      - name: Check release-impacting diffs updated the checklist
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            python3 scripts/release_guard.py changes --base "origin/$BASE_REF" --head HEAD
+          elif [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            python3 scripts/release_guard.py changes --base "$BEFORE_SHA" --head "$HEAD_SHA"
+          else
+            echo "No previous commit to diff against; skipping changed-file release hygiene check."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Zero-friction activation is merged on `main` but not released yet** (`src/llm_router/cli.py`, `src/llm_router/hooks/session-start.py`)
+
+  Includes the onboard wizard, weekly digest, yearly projection, and shadow / suggest / enforce routing modes introduced after `v2.2.0`.
+
+- **Repo-aware YAML config is merged on `main` but not released yet** (`src/llm_router/repo_config.py`, `src/llm_router/cli.py`)
+
+  Adds committed `.llm-router.yml` support plus config linting for repo-scoped routing defaults.
+
+### Changed
+
+- **Session hooks now keep fresher cost and usage context** (`src/llm_router/hooks/session-end.py`, `src/llm_router/hooks/auto-route.py`)
+
+  Session summaries now include cumulative savings with token counts, and OAuth usage snapshots are refreshed more aggressively before routing decisions.
+
+- **Ollama defaults now prefer Gemma 4 where available** (`src/llm_router/cli.py`)
+
+  The local-first model ordering on `main` now prefers Gemma 4 over the older default.
+
+### Fixed
+
+- **Routing enforcement and auto-route blocklists tightened on `main`** (`src/llm_router/hooks/enforce-route.py`, `src/llm_router/hooks/auto-route.py`)
+
+  The post-`v2.2.0` hook work improves MCP-aware routing and closes several enforcement escape hatches.
+
 ## v2.2.0 — Explainable Routing (2026-04-08)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ llm-router share   # copies savings card to clipboard + opens tweet
 
 **Positioning**: *Claude Code's cost autopilot. Stop paying Opus prices for Haiku work.*
 
+> Release discipline: merged-but-unreleased work lives in [`CHANGELOG.md`](CHANGELOG.md)
+> under `Unreleased` until it is tagged and published. See [docs/RELEASING.md](docs/RELEASING.md).
+
 ### Phase 1 — Trust & Proof (Apr–Jun 2026)
 
 | Version | Headline | Status |
@@ -349,13 +352,13 @@ llm-router share   # copies savings card to clipboard + opens tweet
 | v1.3–v2.0 | Foundation, dashboard, enforcement, Agno adapter | ✅ Done |
 | **v2.1** | **Route Simulator** — `llm-router test "<prompt>"` dry-run + `llm_savings` dashboard | ✅ Done |
 | **v2.2** | **Explainable Routing** — `LLM_ROUTER_EXPLAIN=1`, "why not Opus?", per-decision reasoning | ✅ Done |
-| **v2.3** | **Zero-Friction Activation** — onboarding wizard, shadow/suggest/enforce modes, savings card | 📅 Jun 2026 |
+| **v2.3** | **Zero-Friction Activation** — onboarding wizard, shadow/suggest/enforce modes, savings card | 🚧 Unreleased on main |
 
 ### Phase 2 — Smarter Routing (Jun–Aug 2026)
 
 | Version | Headline | Status |
 |---------|----------|--------|
-| **v2.4** | **Repo-Aware YAML Config** — `.llm-router.yml` committed with the codebase | 📅 Jun 2026 |
+| **v2.4** | **Repo-Aware YAML Config** — `.llm-router.yml` committed with the codebase | 🚧 Unreleased on main |
 | **v2.5** | **Context-Aware Routing** — "yes/continue/proceed" resolved from conversation context | 📅 Jul 2026 |
 | **v2.6** | **Latency + Personalized Routing** — p95 latency scoring, per-user acceptance signals | 📅 Aug 2026 |
 
@@ -388,6 +391,8 @@ uv run ruff check src/ tests/
 ```
 
 See [CLAUDE.md](CLAUDE.md) for architecture and module layout.
+
+Release process: [docs/RELEASING.md](docs/RELEASING.md)
 
 ---
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,71 @@
+# Releasing
+
+`llm-router` now follows a release-train model:
+
+- `main` may contain unreleased work.
+- `CHANGELOG.md` must start with `## Unreleased`.
+- `pyproject.toml` is the source of truth for the last published package version.
+- Tagging `vX.Y.Z` publishes to PyPI and creates or updates the matching GitHub Release from `CHANGELOG.md`.
+
+## Every User-Facing Push
+
+If a push changes tools, hooks, install flow, config surface, or Claude Code integration:
+
+1. Update `CHANGELOG.md` under `## Unreleased`.
+2. Update `README.md` if install, setup, configuration, supported tools, or roadmap status changed.
+3. Review Claude/registry metadata if the public MCP surface changed:
+   - `.claude-plugin/plugin.json`
+   - `.claude-plugin/marketplace.json`
+   - `glama.json`
+   - `mcp-registry.json`
+   - `smithery.yaml`
+
+The `Release Hygiene` GitHub Action enforces the required `CHANGELOG.md` and `README.md` updates for the most common user-facing paths.
+
+## Every Release
+
+Before tagging a new version:
+
+1. Move the shipped items from `## Unreleased` into a new `## vX.Y.Z — ...` section in `CHANGELOG.md`.
+2. Bump the version in:
+   - `pyproject.toml`
+   - `uv.lock`
+   - `.claude-plugin/plugin.json`
+   - `.claude-plugin/marketplace.json`
+   - `glama.json`
+   - `mcp-registry.json`
+3. Re-read `README.md` and make sure the install flow, feature list, roadmap status, and tool counts still match the code.
+4. Re-check `smithery.yaml` if config/env vars changed.
+5. Run:
+
+```bash
+uv lock --check
+uv sync --extra dev --extra agno
+uv run pytest tests/ -q --ignore=tests/test_integration.py --timeout=30
+uv run ruff check src/ tests/
+python3 scripts/release_guard.py sync
+```
+
+6. Tag the release:
+
+```bash
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+## What Happens On Tag Push
+
+`.github/workflows/publish.yml` now does all of the release plumbing:
+
+1. Verifies the tag matches `pyproject.toml`.
+2. Runs the publish test gate.
+3. Builds and publishes to PyPI.
+4. Creates or updates the GitHub Release using the matching `CHANGELOG.md` section.
+
+## Guardrails
+
+`scripts/release_guard.py` is the automation source for release hygiene:
+
+- `sync` checks version sync across package/plugin/registry metadata and changelog structure.
+- `changes` checks whether a diff touched user-facing paths that require `CHANGELOG.md` and `README.md`.
+- `title` and `notes` extract GitHub Release content from `CHANGELOG.md`.

--- a/glama.json
+++ b/glama.json
@@ -2,7 +2,7 @@
   "$schema": "https://glama.ai/mcp/schemas/glama-json-schema.json",
   "name": "llm-router",
   "description": "Subscription-aware LLM routing for Claude Code — routes tasks to 20+ providers with complexity classification, pressure-based fallback chains, Codex integration, and cost tracking.",
-  "version": "1.3.0",
+  "version": "2.2.0",
   "license": "MIT",
   "tools": [
     {

--- a/mcp-registry.json
+++ b/mcp-registry.json
@@ -2,7 +2,7 @@
   "name": "llm-router",
   "display_name": "LLM Router for Claude Code",
   "description": "Subscription-aware LLM routing for Claude Code — routes tasks to 20+ providers with complexity classification, pressure-based fallback chains, Codex integration, and cost tracking. Free tasks stay on your Claude subscription; expensive tasks fall back to the cheapest capable external model.",
-  "version": "1.3.0",
+  "version": "2.2.0",
   "homepage": "https://github.com/ypollak2/llm-router",
   "repository": "https://github.com/ypollak2/llm-router",
   "license": "MIT",

--- a/scripts/release_guard.py
+++ b/scripts/release_guard.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from pathlib import Path
+
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PACKAGE_NAME = "claude-code-llm-router"
+CHANGELOG_PATH = "CHANGELOG.md"
+README_PATH = "README.md"
+
+SYNC_TARGETS = (
+    ("pyproject.toml", "package version", "pyproject"),
+    ("uv.lock", "lockfile package version", "uv_lock"),
+    (".claude-plugin/plugin.json", "Claude plugin version", "plugin"),
+    (".claude-plugin/marketplace.json", "Claude marketplace version", "marketplace"),
+    ("glama.json", "Glama registry version", "glama"),
+    ("mcp-registry.json", "MCP registry version", "mcp_registry"),
+)
+
+CHANGELOG_REQUIRED_PATTERNS = (
+    "src/llm_router/cli.py",
+    "src/llm_router/config.py",
+    "src/llm_router/install_hooks.py",
+    "src/llm_router/repo_config.py",
+    "src/llm_router/router.py",
+    "src/llm_router/server.py",
+    "src/llm_router/hooks/**",
+    "src/llm_router/tools/**",
+    ".claude-plugin/**",
+    "glama.json",
+    "mcp-registry.json",
+    "smithery.yaml",
+)
+
+README_REQUIRED_PATTERNS = (
+    "src/llm_router/cli.py",
+    "src/llm_router/install_hooks.py",
+    "src/llm_router/repo_config.py",
+    "src/llm_router/server.py",
+    "src/llm_router/tools/**",
+    ".claude-plugin/**",
+    "glama.json",
+    "mcp-registry.json",
+    "smithery.yaml",
+)
+
+CHECKLIST_LINES = (
+    "`CHANGELOG.md` — always update for user-facing hooks, tools, install flow, config, or metadata changes.",
+    "`README.md` — update when install, setup, configuration, tool surface, or roadmap status changes.",
+    "Versioned release files — keep `pyproject.toml`, `uv.lock`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `glama.json`, and `mcp-registry.json` on the same released version.",
+    "Release outputs — a tag should produce both a PyPI publish and a GitHub Release.",
+)
+
+
+@dataclass
+class ChangelogSection:
+    raw_name: str
+    version: str | None
+    title: str | None
+    body: str
+
+
+def normalize_version(value: str) -> str:
+    return value[1:] if value.startswith("v") else value
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def read_pyproject_version(path: Path) -> str:
+    data = tomllib.loads(read_text(path))
+    return str(data["project"]["version"])
+
+
+def read_uv_lock_version(path: Path) -> str:
+    lines = read_text(path).splitlines()
+    in_package_block = False
+    current_name: str | None = None
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "[[package]]":
+            in_package_block = True
+            current_name = None
+            continue
+        if not in_package_block:
+            continue
+        if stripped.startswith("name = "):
+            name_match = re.match(r'^name = "([^"]+)"$', stripped)
+            current_name = name_match.group(1) if name_match else None
+            continue
+        if current_name != PACKAGE_NAME:
+            continue
+        version_match = re.match(r'^version = "([^"]+)"$', stripped)
+        if version_match:
+            return version_match.group(1)
+    raise ValueError(f"Could not find {PACKAGE_NAME} in {path}")
+
+
+def read_json_version(path: Path) -> str:
+    data = json.loads(read_text(path))
+    return str(data["version"])
+
+
+def read_marketplace_version(path: Path) -> str:
+    data = json.loads(read_text(path))
+    plugins = data.get("plugins", [])
+    if not plugins:
+        raise ValueError(f"No plugins array found in {path}")
+    return str(plugins[0]["version"])
+
+
+def parse_changelog_sections(text: str) -> list[ChangelogSection]:
+    heading_re = re.compile(
+        r"^## (?P<name>Unreleased|v?(?P<version>\d+\.\d+\.\d+))(?: — (?P<title>.+))?$"
+    )
+    sections: list[ChangelogSection] = []
+    current_name: str | None = None
+    current_version: str | None = None
+    current_title: str | None = None
+    current_body: list[str] = []
+
+    for line in text.splitlines():
+        match = heading_re.match(line)
+        if match:
+            if current_name is not None:
+                sections.append(
+                    ChangelogSection(
+                        raw_name=current_name,
+                        version=current_version,
+                        title=current_title,
+                        body="\n".join(current_body).strip(),
+                    )
+                )
+            current_name = match.group("name")
+            current_version = normalize_version(match.group("version")) if match.group("version") else None
+            current_title = match.group("title")
+            current_body = []
+            continue
+        if current_name is not None:
+            current_body.append(line)
+
+    if current_name is not None:
+        sections.append(
+            ChangelogSection(
+                raw_name=current_name,
+                version=current_version,
+                title=current_title,
+                body="\n".join(current_body).strip(),
+            )
+        )
+    return sections
+
+
+def get_latest_released_section(text: str) -> ChangelogSection:
+    sections = parse_changelog_sections(text)
+    if not sections:
+        raise ValueError("CHANGELOG.md has no level-2 sections")
+    if sections[0].raw_name != "Unreleased":
+        raise ValueError("CHANGELOG.md must start with `## Unreleased`")
+    for section in sections[1:]:
+        if section.version:
+            return section
+    raise ValueError("CHANGELOG.md does not contain a released version after `## Unreleased`")
+
+
+def get_release_section(text: str, version: str) -> ChangelogSection:
+    target = normalize_version(version)
+    for section in parse_changelog_sections(text):
+        if section.version == target:
+            return section
+    raise ValueError(f"Could not find CHANGELOG section for v{target}")
+
+
+def load_versions(root: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    values["pyproject"] = read_pyproject_version(root / "pyproject.toml")
+    values["uv_lock"] = read_uv_lock_version(root / "uv.lock")
+    values["plugin"] = read_json_version(root / ".claude-plugin" / "plugin.json")
+    values["marketplace"] = read_marketplace_version(root / ".claude-plugin" / "marketplace.json")
+    values["glama"] = read_json_version(root / "glama.json")
+    values["mcp_registry"] = read_json_version(root / "mcp-registry.json")
+    return values
+
+
+def check_version_sync(root: Path) -> list[str]:
+    errors: list[str] = []
+    values = load_versions(root)
+    source_version = values["pyproject"]
+
+    for path_label, human_label, key in SYNC_TARGETS[1:]:
+        if values[key] != source_version:
+            errors.append(
+                f"{human_label} in {path_label} is {values[key]}, expected {source_version} from pyproject.toml."
+            )
+
+    latest_released = get_latest_released_section(read_text(root / CHANGELOG_PATH))
+    if latest_released.version != source_version:
+        errors.append(
+            f"Latest released CHANGELOG section is v{latest_released.version}, expected v{source_version}."
+        )
+
+    return errors
+
+
+def matches_any(path: str, patterns: tuple[str, ...]) -> bool:
+    return any(fnmatch(path, pattern) for pattern in patterns)
+
+
+def collect_changed_files(root: Path, base_ref: str, head_ref: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", base_ref, head_ref],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def check_changed_files(changed_files: list[str]) -> list[str]:
+    errors: list[str] = []
+    changed_set = set(changed_files)
+
+    if any(matches_any(path, CHANGELOG_REQUIRED_PATTERNS) for path in changed_files):
+        if CHANGELOG_PATH not in changed_set:
+            errors.append(
+                "User-facing files changed but CHANGELOG.md was not updated. "
+                "Add the change under `## Unreleased`."
+            )
+
+    if any(matches_any(path, README_REQUIRED_PATTERNS) for path in changed_files):
+        if README_PATH not in changed_set:
+            errors.append(
+                "Install/config/public-surface files changed but README.md was not updated."
+            )
+
+    return errors
+
+
+def print_checklist() -> None:
+    print("Release checklist:")
+    for line in CHECKLIST_LINES:
+        print(f"- {line}")
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    errors = check_version_sync(Path(args.root))
+    if errors:
+        print("Release sync check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        print_checklist()
+        return 1
+
+    versions = load_versions(Path(args.root))
+    print("Release sync OK")
+    for path_label, human_label, key in SYNC_TARGETS:
+        print(f"- {human_label}: {versions[key]}")
+    return 0
+
+
+def cmd_changes(args: argparse.Namespace) -> int:
+    changed_files = collect_changed_files(Path(args.root), args.base, args.head)
+    if not changed_files:
+        print("No changed files detected for release hygiene check.")
+        return 0
+
+    errors = check_changed_files(changed_files)
+    if errors:
+        print("Release hygiene check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        print("\nChanged files:", file=sys.stderr)
+        for path in changed_files:
+            print(f"- {path}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print_checklist()
+        return 1
+
+    print("Release hygiene OK")
+    print_checklist()
+    return 0
+
+
+def cmd_title(args: argparse.Namespace) -> int:
+    section = get_release_section(read_text(Path(args.root) / CHANGELOG_PATH), args.version)
+    heading = f"v{section.version}"
+    if section.title:
+        heading = f"{heading} — {section.title}"
+    print(heading)
+    return 0
+
+
+def cmd_notes(args: argparse.Namespace) -> int:
+    section = get_release_section(read_text(Path(args.root) / CHANGELOG_PATH), args.version)
+    body = section.body.strip()
+    if args.output:
+        Path(args.output).write_text(body + "\n", encoding="utf-8")
+    else:
+        print(body)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Release hygiene guard for llm-router.")
+    parser.add_argument("--root", default=str(ROOT), help="Repository root")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    sync_parser = subparsers.add_parser("sync", help="Verify release metadata stays in sync.")
+    sync_parser.set_defaults(func=cmd_sync)
+
+    changes_parser = subparsers.add_parser(
+        "changes",
+        help="Verify a diff updated the required changelog/readme surfaces.",
+    )
+    changes_parser.add_argument("--base", required=True, help="Git base ref or SHA")
+    changes_parser.add_argument("--head", required=True, help="Git head ref or SHA")
+    changes_parser.set_defaults(func=cmd_changes)
+
+    title_parser = subparsers.add_parser("title", help="Print the GitHub release title for a version.")
+    title_parser.add_argument("--version", required=True, help="Version string, with or without leading v")
+    title_parser.set_defaults(func=cmd_title)
+
+    notes_parser = subparsers.add_parser("notes", help="Write CHANGELOG notes for a version.")
+    notes_parser.add_argument("--version", required=True, help="Version string, with or without leading v")
+    notes_parser.add_argument("--output", help="Optional output file path")
+    notes_parser.set_defaults(func=cmd_notes)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_guard.py
+++ b/tests/test_release_guard.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "scripts" / "release_guard.py"
+
+spec = importlib.util.spec_from_file_location("release_guard", MODULE_PATH)
+release_guard = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+sys.modules[spec.name] = release_guard
+spec.loader.exec_module(release_guard)
+
+
+def _write_release_files(root: Path, *, version: str, marketplace_version: str | None = None) -> None:
+    marketplace_version = marketplace_version or version
+
+    (root / "pyproject.toml").write_text(
+        "[project]\nname = \"claude-code-llm-router\"\nversion = "
+        f"\"{version}\"\n",
+        encoding="utf-8",
+    )
+    (root / "uv.lock").write_text(
+        "[[package]]\nname = \"claude-code-llm-router\"\nversion = "
+        f"\"{version}\"\n",
+        encoding="utf-8",
+    )
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        f'{{"name":"llm-router","version":"{version}"}}\n',
+        encoding="utf-8",
+    )
+    (root / ".claude-plugin" / "marketplace.json").write_text(
+        '{"plugins":[{"name":"llm-router","version":"'
+        f'{marketplace_version}'
+        '"}]}\n',
+        encoding="utf-8",
+    )
+    (root / "glama.json").write_text(f'{{"version":"{version}"}}\n', encoding="utf-8")
+    (root / "mcp-registry.json").write_text(f'{{"version":"{version}"}}\n', encoding="utf-8")
+    (root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "## Unreleased\n\n"
+        "- Pending work.\n\n"
+        f"## v{version} — Example release\n\n"
+        "- Shipped change.\n",
+        encoding="utf-8",
+    )
+
+
+def test_get_latest_released_section_requires_unreleased() -> None:
+    text = (
+        "# Changelog\n\n"
+        "## Unreleased\n\n"
+        "- Pending.\n\n"
+        "## v2.2.0 — Explainable Routing\n\n"
+        "- Added release.\n"
+    )
+
+    section = release_guard.get_latest_released_section(text)
+
+    assert section.version == "2.2.0"
+    assert section.title == "Explainable Routing"
+
+
+def test_check_changed_files_requires_changelog_and_readme() -> None:
+    changed = ["src/llm_router/repo_config.py"]
+
+    errors = release_guard.check_changed_files(changed)
+
+    assert any("CHANGELOG.md" in error for error in errors)
+    assert any("README.md" in error for error in errors)
+
+
+def test_check_version_sync_accepts_synced_files(tmp_path: Path) -> None:
+    _write_release_files(tmp_path, version="2.2.0")
+
+    errors = release_guard.check_version_sync(tmp_path)
+
+    assert errors == []
+
+
+def test_check_version_sync_rejects_mismatched_marketplace_version(tmp_path: Path) -> None:
+    _write_release_files(tmp_path, version="2.2.0", marketplace_version="1.3.0")
+
+    errors = release_guard.check_version_sync(tmp_path)
+
+    assert any("marketplace" in error.lower() for error in errors)
+
+
+def test_release_notes_extraction_uses_matching_section() -> None:
+    text = (
+        "# Changelog\n\n"
+        "## Unreleased\n\n"
+        "- Pending.\n\n"
+        "## v2.2.0 — Explainable Routing\n\n"
+        "### Added\n\n"
+        "- One.\n\n"
+        "## v2.1.0 — Prior release\n\n"
+        "- Old.\n"
+    )
+
+    section = release_guard.get_release_section(text, "v2.2.0")
+
+    assert "### Added" in section.body
+    assert section.title == "Explainable Routing"

--- a/uv.lock
+++ b/uv.lock
@@ -346,7 +346,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-llm-router"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- add a checked-in release process and a release guard script that enforces version sync and changelog/readme updates
- add a `Release Hygiene` workflow on pushes/PRs and teach tag publishes to create/update GitHub Releases from `CHANGELOG.md`
- fix current metadata drift by syncing marketplace/registry versions to `2.2.0` and marking `v2.3`/`v2.4` as unreleased on `main`

## Verification
- `python3 scripts/release_guard.py sync`
- `python3 scripts/release_guard.py changes --base origin/main --head HEAD`
- `uv run pytest -q tests/test_release_guard.py`
- `uv run ruff check scripts/release_guard.py tests/test_release_guard.py`

## Notes
- Full repo pytest still has two unrelated failures on current `main`: `tests/test_auto_route_hook.py::TestAutoRouteNowRoutes::test_improve_performance_routes` and `tests/test_demo_session_summary.py::TestDemo_SessionSummary::test_empty_session_produces_no_output`.
- A broad `uv run ruff check src/ tests/ scripts` also still hits pre-existing issues in `scripts/demo_routing.py` and `scripts/gen_cast.py`.