### PR TITLE
fix(hooks+session): dashboard savings tracking + enforce-route deadlock recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 **For releases v6.2 and earlier, see [CHANGELOG_ARCHIVE.md](docs/CHANGELOG_ARCHIVE.md).**
 
+## v10.1.2 — Dashboard persistence + enforce-route deadlock recovery + coordination length-gate (2026-06-05)
+
+Three correctness fixes in the routing/enforcement pipeline. None change shipping APIs; all are surgical hook + session_spend edits.
+
+### Fixed
+
+- **Dashboard cumulative savings now persist across sessions.** `SessionSpend.record_reclaimed()` previously only updated the in-memory `session_spend.json`, so subscription-funded savings (Claude Code Haiku/Sonnet routed via the `subscription` provider) showed up in the per-session "Net preserved" panel and vanished the moment the session ended. The fix appends one row per routed call to the `claude_usage` SQLite table (`~/.llm-router/usage.db`), and `_query_cumulative_savings` in `session-end.py` now UNIONs that table alongside `usage` and `savings_stats` for the today/week/month/lifetime rollup. The query uses `date(timestamp, 'localtime')` on both sides of the WHERE clause so the rollup is correct in the midnight-local-but-not-yet-midnight-UTC window. Write is best-effort: if `usage.db` doesn't exist yet (first run before `cost.py` initializes it) the write is silently skipped — tracking never crashes the router.
+- **`enforce-route.py` deadlock recovery — auto-pivot + corrected threshold messaging.** When the same MCP tool was blocked 3+ times within 2 minutes the hook now releases the route-lock and clears the pending tool, breaking would-be infinite loops where the model retried the same blocked call. The block message previously said `/2` while the actual auto-pivot threshold was `/4`; both are now consistent at `/4`, and the message documents the escape valves (`LLM_ROUTER_ENFORCE=off`, the auto-pivot itself). In smart mode, read-only Bash patterns (`ls`, `find`, `git log`, `gh pr view`, …) now pass through for code tasks so the model can investigate before routing, matching the existing Read/Glob/Grep/LS pass-through.
+- **Coordination scoring no longer hijacks long substantive prompts.** The heuristic classifier was scoring `coordination` for multi-sentence prompts that happened to contain common English words like "continue", "run", "test", "verify", "check" — a real-world misfire routed a RouterArena optimization prompt to `qwen2.5:7b` which hallucinated a numpy/cProfile answer unrelated to the input. Two surgical changes: (1) `COORDINATION_MAX_LEN = 150` forces the coordination score to zero for any prompt over 150 characters in `score_categories` — coordination prompts are short by nature (`"y"`, `"yes proceed"`, `"push to main"`); long prompts cannot be coordination regardless of which short coordination words they contain. (2) The coordination/intent regex was trimmed to strong git/deploy verbs (`push`, `pull`, `deploy`, `release`, `publish`, `commit`, `merge`, `sync`, `fetch`, `rebase`) plus short ack tokens (`yes`, `ok`, `y`, `n`, `go ahead`), removing the false-firing common words. The cache layer was cleared as a suspect during diagnosis — it already SHA-256s the full prompt and is keyed correctly; the misfire was fresh Ollama inference, not stale cache.
+- **Lint cleanup.** Removed extraneous f-string prefixes in escalation messages that had no interpolation.
+
+### Tests
+
+- `tests/test_auto_route_signals.py` (19 tests, all passing) — length-gate behavior, previously-misfired prompts no longer score coordination, legitimate short git prompts still win coordination, substantive prompts still classify as code/analyze/generate, end-to-end `classify_prompt` with LLM classifiers disabled.
+- 35 cost tests pass; 52 enforce-route tests pass.
+- Full suite: **2287 / 2287 pass**.
+
+### Verification
+
+- Dashboard end-to-end verified by direct INSERT into `claude_usage` then re-querying `_query_cumulative_savings` — the new row surfaces in today/week/month/lifetime totals with correct localtime handling.
+- Enforce-route deadlock recovery verified against 3-blocks-in-2-min trace (auto-pivot fires, lock releases, pending cleared).
+- Coordination misfire verified against the original RouterArena prompt: pre-fix `coordination: 13` (winner) → post-fix `coordination: 0` (length gate) → `code: 2` wins.
+
 ## v10.1.1 — Expose `llm_session_savings` under the default slim mode (2026-06-03)
 
 ### Fixed

--- a/src/llm_router/hooks/auto-route.py
+++ b/src/llm_router/hooks/auto-route.py
@@ -807,11 +807,16 @@ SIGNALS: dict[str, dict[str, re.Pattern]] = {
         ),
     },
     "coordination": {
+        # Intent: only words that are *strongly* coordination-signal in
+        # isolation. Removed `continue`, `proceed`, `verify`, `check`,
+        # `test`, `update`, `execute`, `run`, `build`, `compile`, `is`,
+        # `are`, `does`, `please`, `thanks` — they fire false positives
+        # on substantive prompts. The remaining set is git/deploy verbs
+        # plus short single-token acknowledgements.
         "intent": re.compile(
-            r"\b(?:push|pull|deploy|release|publish|execute|run|go ahead|"
-            r"proceed|continue|confirm|verify|check|test|build|compile|"
-            r"check if|is|are|does|can you|please|thanks|yes|ok|y|n|"
-            r"commit|merge|sync|update|fetch|rebase)\b",
+            r"\b(?:push|pull|deploy|release|publish|go ahead|"
+            r"yes|ok|y|n|"
+            r"commit|merge|sync|fetch|rebase)\b",
             re.IGNORECASE,
         ),
         "topic": re.compile(
@@ -827,6 +832,14 @@ SIGNALS: dict[str, dict[str, re.Pattern]] = {
         ),
     },
 }
+
+# Coordination prompts are short by nature — "y", "proceed", "push to
+# main", "yes go ahead". Substantive work prompts that *contain*
+# coordination words ("Continue refactor of X", "please update the
+# parser to handle Y") are typically much longer. Above this threshold,
+# the coordination score is forced to zero so the substantive
+# classifier wins.
+COORDINATION_MAX_LEN = 150
 
 # ── Complexity Patterns ──────────────────────────────────────────────────────
 
@@ -885,6 +898,10 @@ def score_categories(text: str) -> dict[str, int]:
                 unique = len({m.lower() if isinstance(m, str) else m[0].lower() for m in matches})
                 total += unique * weight
         scores[category] = total
+    # Length gate: long prompts cannot be coordination, regardless of
+    # which short coordination words happen to appear in them.
+    if len(text) > COORDINATION_MAX_LEN:
+        scores["coordination"] = 0
     return scores
 
 

--- a/src/llm_router/hooks/enforce-route.py
+++ b/src/llm_router/hooks/enforce-route.py
@@ -669,8 +669,8 @@ def main() -> None:
     remaining_until_pivot = max(0, 4 - violation_count)
     if violation_count == 1:
         escalation = (
-            f"\n⚠️  Violation 1/4 — Auto-pivot at violation 4 OR if you retry the "
-            f"same tool 3 times (loop detection)."
+            "\n⚠️  Violation 1/4 — Auto-pivot at violation 4 OR if you retry the "
+            "same tool 3 times (loop detection)."
         )
     elif violation_count == 2:
         escalation = (
@@ -679,9 +679,9 @@ def main() -> None:
         )
     elif violation_count == 3:
         escalation = (
-            f"\n🔴 Violation 3/4 — Next violation triggers auto-pivot. "
-            f"If the routed model genuinely can't help (e.g. needs local files), "
-            f"hit it once more and routing will release."
+            "\n🔴 Violation 3/4 — Next violation triggers auto-pivot. "
+            "If the routed model genuinely can't help (e.g. needs local files), "
+            "hit it once more and routing will release."
         )
     else:  # violation_count >= 4 — handled above but defensive
         escalation = (

--- a/src/llm_router/hooks/enforce-route.py
+++ b/src/llm_router/hooks/enforce-route.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import tempfile
 import time
@@ -75,6 +76,77 @@ def _block_tools_for(task_type: str) -> frozenset:
     if task_type in _QA_TASK_TYPES:
         return _BASE_BLOCK_TOOLS | _QA_ONLY_BLOCK_TOOLS
     return _BASE_BLOCK_TOOLS
+
+
+# ── Read-only Bash allowlist ──────────────────────────────────────────────────
+# In smart mode for code tasks, allow read-only shell commands (find, ls,
+# git status, git log, gh pr view, etc.) so investigation work isn't blocked.
+# Routing intent is preserved: write tools (Edit/Write) and unknown Bash
+# commands still require an llm_* call first.
+
+_BASH_READONLY_PREFIX_RE = re.compile(
+    r"""^\s*(?:
+        ls|find|cat|head|tail|wc|file|stat|du|tree|pwd|whoami|hostname|date|uname|env|
+        grep|rg|ag|fd|
+        git\s+(?:log|status|diff|show|branch|remote|ls-files|check-ignore|
+                rev-parse|describe|tag|blame|worktree\s+list|config\s+--get|
+                config\s+--list|stash\s+list|reflog|shortlog|fsck|count-objects)|
+        gh\s+(?:pr|run|repo|issue|search|api|workflow|release)\s+
+              (?:view|list|checks|status|diff)|
+        gh\s+auth\s+status|gh\s+--help|
+        python3?\s+--version|node\s+--version|uv\s+--version|
+        echo|printf|true|false|test
+    )(?:\s|$|;|\|)""",
+    re.VERBOSE | re.IGNORECASE,
+)
+
+_BASH_FORBIDDEN_RE = re.compile(
+    r"""(?:
+        \brm\b|\brmdir\b|\bmv\b|\bcp\b|\bchmod\b|\bchown\b|\bchgrp\b|\bln\b|\btouch\b|\bmkdir\b|
+        \bgit\s+(?:commit|push|pull|fetch|checkout|reset|rebase|merge|stash\s+(?:push|pop|drop|apply|clear)|
+                  cherry-pick|revert|tag\s+-[df]|clean|remote\s+(?:add|remove|set-url|rename)|
+                  config\s+(?:--global|--system|--unset)|
+                  am|apply|switch|restore|mv|update-ref|symbolic-ref|filter-branch)\b|
+        \bgh\s+(?:pr|issue|release)\s+(?:comment|merge|close|edit|delete|create|reopen|review|ready|update)\b|
+        \bgh\s+auth\s+(?:login|logout|refresh|setup-git|token)\b|
+        \bgh\s+repo\s+(?:create|fork|delete|edit|archive|sync|clone)\b|
+        \bgh\s+secret\b|\bgh\s+variable\b|\bgh\s+run\s+(?:cancel|delete|rerun)\b|
+        \b(?:npm|pnpm|yarn|pip|uv)\s+(?:install|add|remove|sync|build|publish|run|exec|init|create|update|uninstall)\b|
+        \bdocker\b|\bkubectl\b|\bhelm\b|\bterraform\b|\bansible\b|
+        \bsudo\b|\bsu\s+|\bsource\s+|\.\s+/|
+        \bcurl\s+-X\s*(?:POST|PUT|DELETE|PATCH)|\bwget\s+
+    )""",
+    re.VERBOSE | re.IGNORECASE,
+)
+
+
+# Output redirects (>, >>, &>, etc) make any command a write op.
+# Conservative: match the redirect operator anywhere outside quotes.
+# False positives on quoted ">" are acceptable — those are rare in read-only work.
+_BASH_REDIRECT_RE = re.compile(r"(?<![<>])(?:>>|&>|>)(?![=>])")
+
+
+def _is_readonly_bash(command: str) -> bool:
+    """Return True if a Bash command is conservatively read-only.
+
+    Read-only means: inspects state but doesn't modify the filesystem,
+    repository, remote services, or installed packages. Used to let
+    investigation work through without satisfying routing first.
+
+    Conservative: unknown prefixes return False (fail-closed). Redirects,
+    forbidden subcommands, and command substitution (`$(...)`, backticks)
+    block the allowance.
+    """
+    if not command or not command.strip():
+        return False
+    if _BASH_FORBIDDEN_RE.search(command):
+        return False
+    if _BASH_REDIRECT_RE.search(command):
+        return False
+    # Command substitution can hide writes inside otherwise-read-only commands.
+    if "$(" in command or "`" in command:
+        return False
+    return bool(_BASH_READONLY_PREFIX_RE.match(command))
 
 
 # ── Session-Type Tracking ─────────────────────────────────────────────────────
@@ -485,6 +557,14 @@ def main() -> None:
                 pass  # Block reads for Q&A tasks — fall through to violation handling
             else:
                 sys.exit(0)  # Allow reads for code tasks (needed for implementation)
+        elif tool_name == "Bash" and task_type not in _QA_TASK_TYPES:
+            # Code/non-Q&A tasks: allow read-only Bash (find, ls, git log, gh pr view, ...).
+            # Investigation often needs shell; routing intent is preserved because
+            # writes (rm, git push, npm install, etc.) still hit the violation path.
+            bash_command = hook_input.get("tool_input", {}).get("command", "")
+            if _is_readonly_bash(bash_command):
+                sys.exit(0)
+            # else: fall through to violation handling (write/unknown Bash)
         elif tool_name not in _block_tools_for(task_type):
             sys.exit(0)  # Allow non-blocked tools
         # else: fall through to violation handling
@@ -500,11 +580,43 @@ def main() -> None:
     if enforce == "soft":
         sys.exit(0)  # soft mode: logged, allowed
 
+    # ── Deadlock unblock: loop detection → immediate auto-pivot ──────────────
+    # If the same tool has been blocked 3+ times in 2 minutes, Claude is stuck
+    # retrying the same approach. The routed model can't help (otherwise we'd
+    # have made progress by now), so release the lock and let work continue.
+    # This is the primary escape valve for investigation deadlocks where the
+    # routed model can't access local files/shell.
+    if loop_detected:
+        try:
+            _ROUTER_DIR.mkdir(parents=True, exist_ok=True)
+            ts = time.strftime("%Y-%m-%d %H:%M:%S")
+            with _LOG_PATH.open("a", encoding="utf-8") as f:
+                f.write(
+                    f"[{ts}] AUTO-PIVOT (loop) session={session_id[:12]} "
+                    f"tool={tool_name} count={loop_detected['count']}\n"
+                )
+        except OSError:
+            pass
+        _clear_pending(session_id)  # Clear pending so subsequent tools also pass
+        _clear_violation_count(session_id)
+        sys.exit(0)
+
     # ── Stuck-pattern detection: auto-pivot after 4 violations per turn ──────────
     # auto-route.py resets violation count on each new user prompt, so this counter
     # is per-turn. After 4 blocked attempts in one turn, allow through to prevent
     # deadlocks — but only for THIS turn (next prompt resets).
     if violation_count >= 4:
+        try:
+            _ROUTER_DIR.mkdir(parents=True, exist_ok=True)
+            ts = time.strftime("%Y-%m-%d %H:%M:%S")
+            with _LOG_PATH.open("a", encoding="utf-8") as f:
+                f.write(
+                    f"[{ts}] AUTO-PIVOT (count) session={session_id[:12]} "
+                    f"violations={violation_count}\n"
+                )
+        except OSError:
+            pass
+        _clear_pending(session_id)  # Persist the pivot for the rest of the turn
         sys.exit(0)  # Allow this tool call to prevent deadlock
 
     if enforce == "smart":
@@ -550,13 +662,32 @@ def main() -> None:
             f"  3. Reason: {task_type} tasks are routed for cost efficiency."
         )
 
-    # Show violation count and escalation path
+    # Show violation count and escalation path. Two unblock mechanisms exist:
+    #   1) Loop detection: same tool blocked 3+ times in 2 min → instant release
+    #   2) Count-based: 4 total violations this turn → release
     escalation = ""
+    remaining_until_pivot = max(0, 4 - violation_count)
     if violation_count == 1:
-        escalation = "\n⚠️  Violation 1/2 — One more blocked tool will auto-downgrade enforcement & allow routing."
-    elif violation_count >= 2:
-        escalation = f"\n🔴 Violation {violation_count}/2+ — This session will auto-downgrade to soft enforcement after this turn.\n" \
-                     f"    CALL {expected_tool} NOW to avoid being soft-blocked."
+        escalation = (
+            f"\n⚠️  Violation 1/4 — Auto-pivot at violation 4 OR if you retry the "
+            f"same tool 3 times (loop detection)."
+        )
+    elif violation_count == 2:
+        escalation = (
+            f"\n⚠️  Violation 2/4 — {remaining_until_pivot} more violations before "
+            f"auto-pivot releases the lock."
+        )
+    elif violation_count == 3:
+        escalation = (
+            f"\n🔴 Violation 3/4 — Next violation triggers auto-pivot. "
+            f"If the routed model genuinely can't help (e.g. needs local files), "
+            f"hit it once more and routing will release."
+        )
+    else:  # violation_count >= 4 — handled above but defensive
+        escalation = (
+            f"\n🔴 Violation {violation_count}/4 — Auto-pivot already engaged; "
+            f"this block is unexpected."
+        )
 
     # Detect investigation loops (same tool called 3+ times in 2 minutes)
     loop_warning = ""
@@ -585,6 +716,10 @@ def main() -> None:
         f"  burns full model cost with no savings. For {complexity} tasks, that's expensive.\n\n"
         f"NEXT STEP (required):\n"
         f"{action}\n\n"
+        f"Escape valves (if the routed model truly can't help):\n"
+        f"  • Call ANY llm_* tool (even a trivial llm_query) — clears the lock for this turn\n"
+        f"  • Loop detection: retry the same tool 3 times → auto-pivot\n"
+        f"  • Or hit violation 4 → auto-pivot\n\n"
         f"Debug options:\n"
         f"  • View compliance log: {_LOG_PATH}\n"
         f"  • Soft-fail for testing: export LLM_ROUTER_ENFORCE=soft\n"

--- a/src/llm_router/hooks/session-end.py
+++ b/src/llm_router/hooks/session-end.py
@@ -382,6 +382,23 @@ def _query_cumulative_savings() -> list[tuple[str, int, int, int, float]]:
                     calls += ss_rows[0]
                     saved += ss_rows[1]
 
+            # Include Claude Code subscription savings (Haiku/Sonnet vs Opus baseline).
+            # session_spend.record_reclaimed() writes one row per routed call into
+            # claude_usage with the Opus-equivalent USD saved. Without this query
+            # branch, those savings only appear in the per-session "Net preserved"
+            # panel and never roll up into today/week/month/lifetime totals.
+            has_claude_usage = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='claude_usage'"
+            ).fetchone() is not None
+            if has_claude_usage:
+                cu_rows = conn.execute(
+                    f"SELECT COUNT(*), COALESCE(SUM(cost_saved_usd),0) "
+                    f"FROM claude_usage WHERE {where}"
+                ).fetchone()
+                if cu_rows and cu_rows[0] > 0:
+                    calls += cu_rows[0]
+                    saved += cu_rows[1]
+
             results.append((label, calls, total_in, total_out, saved))
         conn.close()
     except Exception:

--- a/src/llm_router/session_spend.py
+++ b/src/llm_router/session_spend.py
@@ -158,6 +158,40 @@ class SessionSpend:
         else:
             self.gates_failed += 1
         self._persist()
+        # Also persist a SQLite row so the session-end dashboard's cumulative
+        # "today/this week/lifetime" savings rollup reflects subscription-funded
+        # routing (Claude Code Haiku/Sonnet vs Opus). Without this, only the
+        # current-session "Net preserved" panel sees these savings — they vanish
+        # the moment the session ends. The dashboard query joins this table
+        # via _query_cumulative_savings to surface them.
+        try:
+            self._persist_to_claude_usage(tokens_reclaimed, opus_equivalent_usd)
+        except Exception:
+            pass  # Tracking is best-effort — never crash the router.
+
+    def _persist_to_claude_usage(
+        self, tokens_reclaimed: int, opus_equivalent_usd: float
+    ) -> None:
+        """Append a row to ~/.llm-router/usage.db claude_usage table."""
+        import sqlite3
+        db_path = SESSION_SPEND_FILE.parent / "usage.db"
+        if not db_path.exists():
+            return  # No DB → no cumulative tracking yet; cost.py creates on first use.
+        # Pick the model that took most cost this session as the attribution model
+        # (rough but cheap — the alternative is per-call attribution which would
+        # require threading the model name through record_reclaimed).
+        attribution_model = (
+            max(self.per_model, key=lambda m: self.per_model[m]["cost_usd"])
+            if self.per_model else "subscription"
+        )
+        with sqlite3.connect(str(db_path), timeout=2.0) as conn:
+            conn.execute(
+                "INSERT INTO claude_usage "
+                "(model, tokens_used, complexity, cost_saved_usd) "
+                "VALUES (?, ?, ?, ?)",
+                (attribution_model, tokens_reclaimed, "auto", opus_equivalent_usd),
+            )
+            conn.commit()
 
     @property
     def net_savings_usd(self) -> float:

--- a/tests/test_auto_route_signals.py
+++ b/tests/test_auto_route_signals.py
@@ -1,0 +1,221 @@
+"""Regression tests for the heuristic classifier's coordination signals.
+
+These tests lock in the fix for a class of false positives where
+substantive prompts (multi-sentence, > 150 chars) containing common
+English words like "continue", "test", "verify" were being scored as
+``coordination`` and routed to a tiny Ollama model that hallucinated
+unrelated answers.
+
+The fix has two parts:
+
+1. ``COORDINATION_MAX_LEN`` — coordination score is zeroed when the
+   prompt is longer than the threshold. Long prompts cannot be
+   coordination regardless of which short coordination words appear in
+   them.
+
+2. The ``coordination/intent`` regex was trimmed to remove ambiguous
+   English (continue, proceed, verify, check, test, update, is, are,
+   does, please, thanks, execute, run, build, compile). What remains is
+   git/deploy verbs (push, pull, deploy, release, publish, commit,
+   merge, sync, fetch, rebase) plus short acks (yes, ok, y, n,
+   go ahead).
+
+Loading auto-route.py is awkward because of the hyphen in the filename;
+we use importlib.util.spec_from_file_location to import it as a module.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_auto_route():
+    cached = sys.modules.get("auto_route_under_test_signals")
+    if cached is not None:
+        return cached
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "src" / "llm_router" / "hooks" / "auto-route.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "auto_route_under_test_signals", path
+    )
+    assert spec and spec.loader, f"Could not load spec for {path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["auto_route_under_test_signals"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def auto_route():
+    return _load_auto_route()
+
+
+# ── Length gate ──────────────────────────────────────────────────────────────
+
+
+class TestCoordinationLengthGate:
+    """``score_categories`` zeroes coordination for prompts above the threshold."""
+
+    def test_threshold_constant_is_exposed(self, auto_route):
+        # The threshold is referenced by tests + tooling — must stay public.
+        assert isinstance(auto_route.COORDINATION_MAX_LEN, int)
+        assert auto_route.COORDINATION_MAX_LEN >= 100
+
+    def test_long_prompt_with_coordination_words_scores_zero(self, auto_route):
+        # Use only coordination-adjacent words but make the prompt long.
+        text = "yes " + ("push pull merge commit " * 20)
+        assert len(text) > auto_route.COORDINATION_MAX_LEN
+        scores = auto_route.score_categories(text)
+        assert scores["coordination"] == 0
+
+    def test_short_prompt_with_coordination_words_scores_nonzero(self, auto_route):
+        text = "yes push to main and merge"
+        assert len(text) <= auto_route.COORDINATION_MAX_LEN
+        scores = auto_route.score_categories(text)
+        assert scores["coordination"] > 0
+
+
+# ── Real-world misfire fixtures (these were the bugs) ────────────────────────
+
+
+class TestPreviouslyMisfiredPrompts:
+    """Each of these used to win coordination by ≥ 2x; they must not anymore."""
+
+    def test_routerarena_continuation_prompt_does_not_score_coordination(
+        self, auto_route
+    ):
+        text = (
+            "Continue RouterArena optimization for PR #132. Branch reset to "
+            "baseline 065cca5 after Lever #3 was rejected as test-set leakage. "
+            "Read docs/ROUTERARENA_IMPROVEMENT_PLAN.md and start with Tier 1 "
+            "(free wins). Before any submission, run uv run python "
+            "scripts/check_submission_integrity.py."
+        )
+        scores = auto_route.score_categories(text)
+        assert scores["coordination"] == 0, (
+            f"Long substantive prompt still scoring coordination: {scores}"
+        )
+
+    def test_llm_router_fix_request_does_not_win_coordination(self, auto_route):
+        # Short prompt — length gate does NOT apply, but the trimmed
+        # intent regex no longer matches "continue", so coordination is
+        # at most tied with substantive categories rather than dominating.
+        text = "I want to continue with the fix for the llm-router and its branch"
+        scores = auto_route.score_categories(text)
+        winner = max(scores, key=lambda k: scores[k])
+        assert winner != "coordination", (
+            f"Substantive fix request still winning coordination: {scores}"
+        )
+
+    def test_long_prompt_with_continue_and_test_does_not_score_coordination(
+        self, auto_route
+    ):
+        text = (
+            "I want to continue working on the test suite and verify "
+            "the integration tests pass before we push the branch. "
+            "Please check whether the build is green on CI and update "
+            "the docs if anything changed in the public API."
+        )
+        scores = auto_route.score_categories(text)
+        assert scores["coordination"] == 0
+
+
+# ── Legitimate coordination must still win ───────────────────────────────────
+
+
+class TestLegitimateCoordinationStillWins:
+    """Short git/deploy prompts must still be classified as coordination."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "push to main",
+            "merge after CI passes",
+            "rebase onto origin/main",
+            "deploy to staging",
+            "yes go ahead",
+            "ok proceed",  # "proceed" no longer in intent but "ok" is
+            "publish the release",
+            "fetch and pull",
+        ],
+    )
+    def test_short_git_prompt_wins_coordination(self, auto_route, text):
+        scores = auto_route.score_categories(text)
+        winner = max(scores, key=lambda k: scores[k])
+        assert winner == "coordination", (
+            f"Expected coordination, got {winner} for {text!r}: {scores}"
+        )
+
+
+# ── Substantive prompts must still classify correctly ────────────────────────
+
+
+class TestSubstantiveStillClassifiesCorrectly:
+    """Code/analyze/generate prompts must not regress after the fix."""
+
+    def test_implement_classifies_as_code(self, auto_route):
+        scores = auto_route.score_categories(
+            "Implement a function that parses JSON safely."
+        )
+        winner = max(scores, key=lambda k: scores[k])
+        assert winner == "code", scores
+
+    def test_refactor_classifies_as_code(self, auto_route):
+        scores = auto_route.score_categories(
+            "Refactor the cache module to use SHA256 keys."
+        )
+        winner = max(scores, key=lambda k: scores[k])
+        assert winner == "code", scores
+
+    def test_explain_classifies_substantive(self, auto_route):
+        # Should be query or analyze, but definitely not coordination.
+        scores = auto_route.score_categories(
+            "Explain how the cache eviction policy works."
+        )
+        winner = max(scores, key=lambda k: scores[k])
+        assert winner != "coordination", scores
+
+
+# ── End-to-end classify_prompt sanity (no Ollama / API calls) ────────────────
+
+
+class TestClassifyPromptIntegration:
+    """Exercise the full chain on the previously-misfired prompt.
+
+    ``classify_prompt`` may fall through to Ollama or the cheap API
+    layer. We set the env var that disables those so the test runs
+    offline and is deterministic.
+    """
+
+    @pytest.fixture(autouse=True)
+    def disable_llm_classifiers(self, auto_route, monkeypatch):
+        monkeypatch.setattr(auto_route, "DISABLE_LLM_CLASSIFIERS", True)
+
+    def test_routerarena_prompt_routes_substantive_not_coordination(self, auto_route):
+        text = (
+            "Continue RouterArena optimization for PR #132. Branch reset to "
+            "baseline 065cca5 after Lever #3 was rejected as test-set leakage. "
+            "Read docs/ROUTERARENA_IMPROVEMENT_PLAN.md and start with Tier 1 "
+            "(free wins). Before any submission, run uv run python "
+            "scripts/check_submission_integrity.py."
+        )
+        result = auto_route.classify_prompt(text)
+        assert result is not None
+        assert result["task_type"] != "coordination", result
+
+    def test_short_continue_no_longer_returns_coordination(self, auto_route):
+        # Bare "continue" used to return coordination/moderate. After the
+        # trim it is too short to classify; classify_prompt returns None
+        # (filtered by the < 8 chars guard) and the downstream skip logic
+        # handles it. This is the correct behavior — a bare ack does not
+        # need a route hint.
+        result = auto_route.classify_prompt("continue")
+        # 8 chars exactly — at the boundary. Either None or non-coordination is OK.
+        if result is not None:
+            assert result["task_type"] != "coordination", result

--- a/tests/test_route_enforcement_hooks.py
+++ b/tests/test_route_enforcement_hooks.py
@@ -396,3 +396,239 @@ def test_auto_route_logs_unrouted_previous_turn_on_next_prompt(tmp_path):
     assert "task=query/simple" in log_text
     # Prior unrouted turn context is now in contextForAgent, not systemMessage
     assert "PREVIOUS TURN VIOLATED ROUTING" in ctx or "prior unrouted turn" in ctx
+
+
+# ── Read-only Bash allowlist (smart mode, code tasks) ─────────────────────────
+
+
+READONLY_BASH_CASES = [
+    "ls /tmp",
+    "find . -name '*.py'",
+    "cat README.md",
+    "git status",
+    "git log --oneline -5",
+    "git diff HEAD",
+    "git show HEAD:path/to/file.py",
+    "gh pr view 132",
+    "gh run list --limit 5",
+    "git log --oneline | head -10",
+    "grep -r foo src/",
+    "wc -l file.txt",
+]
+
+WRITE_BASH_CASES = [
+    "rm -rf /tmp/data",
+    "git push origin main",
+    "git commit -m msg",
+    "git checkout main",
+    "git reset --hard HEAD",
+    "gh pr comment 132 --body /evaluate",
+    "gh pr merge 132",
+    "npm install",
+    "uv sync",
+    "pip install requests",
+    "sudo apt-get update",
+    "curl -X POST https://example.com",
+    "echo hi > file.txt",
+    "mv a b",
+]
+
+
+@pytest.mark.parametrize("command", READONLY_BASH_CASES)
+def test_readonly_bash_allowed_for_code_tasks(tmp_path, command):
+    """Smart mode: investigation-style Bash passes through for code tasks."""
+    session_id = "sess-bash-readonly"
+    _write_pending(tmp_path, session_id, task_type="code", complexity="moderate",
+                   expected_tool="llm_code")
+
+    result = _run_hook(
+        ENFORCE_ROUTE_HOOK,
+        {
+            "session_id": session_id,
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        },
+        home=tmp_path,
+    )
+
+    assert result.returncode == 0, f"hook failed: {result.stderr}"
+    # Empty stdout = allow (no block decision emitted)
+    assert result.stdout.strip() == "", (
+        f"expected allow for read-only Bash {command!r}, got: {result.stdout}"
+    )
+
+
+@pytest.mark.parametrize("command", WRITE_BASH_CASES)
+def test_write_bash_still_blocked_for_code_tasks(tmp_path, command):
+    """Smart mode: write/destructive Bash still requires routing."""
+    session_id = "sess-bash-write"
+    _write_pending(tmp_path, session_id, task_type="code", complexity="moderate",
+                   expected_tool="llm_code")
+
+    result = _run_hook(
+        ENFORCE_ROUTE_HOOK,
+        {
+            "session_id": session_id,
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        },
+        home=tmp_path,
+    )
+
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["decision"] == "block", (
+        f"expected block for write Bash {command!r}, got: {out}"
+    )
+
+
+def test_readonly_bash_blocked_for_qa_tasks(tmp_path):
+    """Q&A tasks must route — even read-only Bash bypasses the cheap model."""
+    session_id = "sess-bash-qa"
+    _write_pending(tmp_path, session_id, task_type="query", complexity="simple",
+                   expected_tool="llm_query")
+
+    result = _run_hook(
+        ENFORCE_ROUTE_HOOK,
+        {
+            "session_id": session_id,
+            "tool_name": "Bash",
+            "tool_input": {"command": "git status"},
+        },
+        home=tmp_path,
+    )
+
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    assert out["decision"] == "block"
+
+
+# ── Loop detection → auto-pivot ───────────────────────────────────────────────
+
+
+def test_loop_detection_triggers_auto_pivot(tmp_path):
+    """3+ blocked same-tool calls in 2 min should release the lock."""
+    session_id = "sess-loop"
+    _write_pending(tmp_path, session_id, task_type="query", complexity="simple",
+                   expected_tool="llm_query")
+
+    # Seed tool history with 3 prior Bash calls in the last 2 minutes.
+    router_dir = tmp_path / ".llm-router"
+    history_path = router_dir / f"tool_history_{session_id}.json"
+    now = time.time()
+    history_path.write_text(
+        json.dumps({
+            "calls": [
+                {"tool": "Bash", "timestamp": now - 30},
+                {"tool": "Bash", "timestamp": now - 20},
+                {"tool": "Bash", "timestamp": now - 10},
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    result = _run_hook(
+        ENFORCE_ROUTE_HOOK,
+        {
+            "session_id": session_id,
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo hi > /tmp/out"},  # write op, normally blocked
+        },
+        home=tmp_path,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        f"loop should have released lock; got block: {result.stdout}"
+    )
+
+    # Pending state should be cleared so subsequent tools also pass.
+    pending_path = router_dir / f"pending_route_{session_id}.json"
+    assert not pending_path.exists(), "loop pivot should clear pending state"
+
+    # Log entry should be present.
+    log_text = (router_dir / "enforcement.log").read_text(encoding="utf-8")
+    assert "AUTO-PIVOT (loop)" in log_text
+
+
+def test_violation_count_pivot_at_4(tmp_path):
+    """Auto-pivot triggers at violation 4 (matches the updated UX messaging)."""
+    session_id = "sess-count-pivot"
+    _write_pending(tmp_path, session_id, task_type="query", complexity="simple",
+                   expected_tool="llm_query")
+
+    # Seed violation counter at 3 — next blocked call hits 4 and triggers pivot.
+    router_dir = tmp_path / ".llm-router"
+    counter_path = router_dir / f"violations_{session_id}.json"
+    counter_path.write_text(
+        json.dumps({"count": 3, "last_violation_at": time.time()}),
+        encoding="utf-8",
+    )
+
+    result = _run_hook(
+        ENFORCE_ROUTE_HOOK,
+        {
+            "session_id": session_id,
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "/tmp/x", "old_string": "a", "new_string": "b"},
+        },
+        home=tmp_path,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", (
+        f"4th violation should pivot; got block: {result.stdout}"
+    )
+    log_text = (router_dir / "enforcement.log").read_text(encoding="utf-8")
+    assert "AUTO-PIVOT (count)" in log_text
+
+
+# ── Messaging consistency ─────────────────────────────────────────────────────
+
+
+def test_block_message_shows_correct_threshold(tmp_path):
+    """Block message should reference /4 (matches actual threshold), not /2."""
+    session_id = "sess-msg-threshold"
+    _write_pending(tmp_path, session_id, task_type="query", complexity="simple",
+                   expected_tool="llm_query")
+
+    result = _run_hook(
+        ENFORCE_ROUTE_HOOK,
+        {
+            "session_id": session_id,
+            "tool_name": "Bash",
+            "tool_input": {"command": "rm -rf /"},
+        },
+        home=tmp_path,
+    )
+
+    assert result.returncode == 0
+    out = json.loads(result.stdout)
+    reason = out["reason"]
+    assert "1/4" in reason or "/4" in reason, (
+        f"block message should mention /4 threshold, got: {reason[:300]}"
+    )
+    # Old misleading text must not reappear.
+    assert "1/2" not in reason
+    assert "2/2+" not in reason
+
+
+def test_block_message_documents_escape_valve(tmp_path):
+    """Block message must mention the llm_* clear-lock escape."""
+    session_id = "sess-escape"
+    _write_pending(tmp_path, session_id)
+
+    result = _run_hook(
+        ENFORCE_ROUTE_HOOK,
+        {
+            "session_id": session_id,
+            "tool_name": "Bash",
+            "tool_input": {"command": "rm -rf /"},
+        },
+        home=tmp_path,
+    )
+
+    out = json.loads(result.stdout)
+    assert "Escape valves" in out["reason"]
+    assert "llm_" in out["reason"]
+    assert "loop" in out["reason"].lower() or "retry the same tool" in out["reason"].lower()


### PR DESCRIPTION
## Summary

Two related fixes discovered while using llm-router in a long Claude Code session.

### Dashboard savings tracking

**Bug:** Session-end dashboard `SAVINGS today/this week/lifetime` showed $0.00 today even after a session generated real subscription savings (visible in the per-session "Net preserved $X" panel).

**Root cause:** `record_reclaimed()` in `session_spend.py` writes to `~/.llm-router/session_spend.json` only. Nothing persisted to SQLite, so cumulative queries returned 0. The `claude_usage` table existed but had 0 rows lifetime — nothing ever wrote to it.

**Fix:**
- `session_spend.py`: `record_reclaimed()` now also INSERTs a row into `claude_usage` SQLite table with the Opus-equivalent USD saved. Best-effort (wrapped in try/except so tracking failure never crashes the router).
- `session-end.py:_query_cumulative_savings()`: UNIONs `claude_usage` into the rollup, alongside the existing `usage` and `savings_stats` queries.

**Verified end-to-end:** direct `INSERT INTO claude_usage VALUES ('test',1000,'auto',0.05)` → dashboard query now shows `today: 1 calls, $0.0500 saved`.

### Enforce-route deadlock recovery

**Bug:** Investigation work in a routed session deadlocked the assistant. The hook blocked Bash with "Violation 1/2 — auto-downgrade after this turn" but the actual auto-pivot threshold was 4 (off-by-2 messaging). Loop detection (3 same-tool blocks in 2min) was computed but never acted on.

**Fix in `enforce-route.py`:**
- Loop-detection auto-pivot: 3+ same-tool blocks in 2min release the lock AND clear pending state. Primary escape valve for investigation tasks where the routed model genuinely can't help.
- Read-only Bash allowlist: in smart mode for code tasks, allow `ls`, `find`, `git log/status/diff`, `gh pr view`, `cat`, `head`, `tail`, `wc`, `grep`, etc. Writes (`rm`, `git push`, `npm install`, redirects, command substitution) still blocked.
- Messaging fix: changed `/2 → /4` to match the actual count threshold.
- Block message now documents three escape valves: call any `llm_*` to clear lock, retry same tool 3x (loop detection), or hit violation 4 (count pivot).

## Test plan

- [x] `tests/test_cost.py tests/test_cost_host.py` — 35 cost tests pass
- [x] `tests/test_enforce_route_safety.py tests/test_route_enforcement_hooks.py` — 52 enforce-route tests pass (includes new ones for loop pivot + bash allowlist + messaging)
- [x] Dashboard query verified end-to-end with manual INSERT + query

🤖 Generated with [Claude Code](https://claude.com/claude-code)