### PR TITLE
Add EvoLink provider routing support

### DIFF
--- a/src/llm_router/config.py
+++ b/src/llm_router/config.py
@@ -85,6 +85,7 @@ class RouterConfig(BaseSettings):
     # we surface it here only to gate `available_providers` and to enable the
     # `~/.llm-router/config.yaml` fallback path used by enterprise installs.
     openrouter_api_key: str = ""
+    evolink_api_key: str = ""
 
     # ── Claude Pro/Max subscription ──
     # Set to True when using llm-router inside Claude Code (Pro/Max subscription).
@@ -290,6 +291,7 @@ class RouterConfig(BaseSettings):
         "xai_api_key": ("xai", "XAI_API_KEY"),
         "cohere_api_key": ("cohere", "COHERE_API_KEY"),
         "openrouter_api_key": ("openrouter", "OPENROUTER_API_KEY"),
+        "evolink_api_key": ("evolink", "EVOLINK_API_KEY"),
         "fal_key": ("fal", "FAL_KEY"),
         "stability_api_key": ("stability", "STABILITY_API_KEY"),
         "elevenlabs_api_key": ("elevenlabs", "ELEVENLABS_API_KEY"),
@@ -340,7 +342,7 @@ class RouterConfig(BaseSettings):
         return self.available_providers & {
             "openai", "gemini", "perplexity", "anthropic",
             "mistral", "deepseek", "groq", "together", "xai", "cohere", "ollama",
-            "huggingface", "openrouter",
+            "huggingface", "openrouter", "evolink",
         }
 
     @property

--- a/src/llm_router/policies/standard.yaml
+++ b/src/llm_router/policies/standard.yaml
@@ -21,6 +21,7 @@ workhorses:
   - gemini/gemini-2.5-pro
   - deepseek/deepseek-chat
   - openai/gpt-4o
+  - evolink/gpt-5.2
   - anthropic/claude-sonnet-4-6
   - anthropic/claude-haiku-4-5-20251001
 
@@ -31,6 +32,7 @@ fallback_chain_complex:
   - gemini/gemini-2.5-pro
   - openai/gpt-4o
   - openai/o3
+  - evolink/gpt-5.2
   - xai/grok-3
 
 specialists: {}
@@ -44,17 +46,20 @@ chains:
       - groq/llama-3.3-70b-versatile
       - deepseek/deepseek-chat
       - openai/gpt-4o-mini
+      - evolink/gpt-5.2
       - anthropic/claude-haiku-4-5-20251001
     research:
       - anthropic/claude-haiku-4-5-20251001
       - gemini/gemini-2.5-flash
       - openai/gpt-4o-mini
+      - evolink/gpt-5.2
     generate:
       - codex/gpt-4o-mini
       - gemini/gemini-2.5-flash
       - deepseek/deepseek-chat
       - mistral/mistral-small-latest
       - openai/gpt-4o-mini
+      - evolink/gpt-5.2
       - anthropic/claude-haiku-4-5-20251001
     analyze:
       - codex/gpt-4o-mini
@@ -62,6 +67,7 @@ chains:
       - deepseek/deepseek-reasoner
       - groq/llama-3.3-70b-versatile
       - openai/gpt-4o-mini
+      - evolink/gpt-5.2
       - anthropic/claude-haiku-4-5-20251001
     code:
       - codex/gpt-4o-mini
@@ -69,6 +75,7 @@ chains:
       - gemini/gemini-2.5-flash
       - groq/llama-3.3-70b-versatile
       - openai/gpt-4o-mini
+      - evolink/gpt-5.2
       - anthropic/claude-haiku-4-5-20251001
     image:
       - fal/flux-dev
@@ -89,18 +96,21 @@ chains:
       - gemini/gemini-2.5-pro
       - deepseek/deepseek-chat
       - openai/gpt-4o
+      - evolink/gpt-5.2
       - anthropic/claude-sonnet-4-6
       - anthropic/claude-haiku-4-5-20251001
     research:
       - anthropic/claude-sonnet-4-6
       - gemini/gemini-2.5-pro
       - openai/gpt-4o
+      - evolink/gpt-5.2
     generate:
       - codex/gpt-4o
       - gemini/gemini-2.5-pro
       - deepseek/deepseek-chat
       - openai/gpt-4o
       - cohere/command-r-plus
+      - evolink/gpt-5.2
       - anthropic/claude-sonnet-4-6
       - anthropic/claude-haiku-4-5-20251001
     analyze:
@@ -108,6 +118,7 @@ chains:
       - gemini/gemini-2.5-pro
       - deepseek/deepseek-reasoner
       - openai/gpt-4o
+      - evolink/gpt-5.2
       - anthropic/claude-sonnet-4-6
       - anthropic/claude-haiku-4-5-20251001
     code:
@@ -115,6 +126,7 @@ chains:
       - gemini/gemini-2.5-pro
       - deepseek/deepseek-chat
       - openai/gpt-4o
+      - evolink/gpt-5.2
       - anthropic/claude-sonnet-4-6
       - anthropic/claude-haiku-4-5-20251001
     image:
@@ -139,11 +151,13 @@ chains:
       - gemini/gemini-2.5-pro
       - openai/gpt-4o
       - openai/o3
+      - evolink/gpt-5.2
       - xai/grok-3
     research:
       - anthropic/claude-opus-4-6
       - gemini/gemini-2.5-pro
       - openai/o3
+      - evolink/gpt-5.2
     generate:
       - anthropic/claude-opus-4-6
       - anthropic/claude-sonnet-4-6
@@ -151,12 +165,14 @@ chains:
       - gemini/gemini-2.5-pro
       - openai/gpt-4o
       - openai/o3
+      - evolink/gpt-5.2
     analyze:
       - anthropic/claude-opus-4-6
       - anthropic/claude-sonnet-4-6
       - deepseek/deepseek-reasoner
       - gemini/gemini-2.5-pro
       - openai/o3
+      - evolink/gpt-5.2
     code:
       - anthropic/claude-opus-4-6
       - anthropic/claude-sonnet-4-6
@@ -164,6 +180,7 @@ chains:
       - gemini/gemini-2.5-pro
       - openai/gpt-4o
       - openai/o3
+      - evolink/gpt-5.2
     image:
       - gemini/imagen-3
       - openai/dall-e-3

--- a/src/llm_router/provider_quirks.py
+++ b/src/llm_router/provider_quirks.py
@@ -34,6 +34,7 @@ from typing import Any, Protocol, runtime_checkable
 __all__ = [
     "ProviderQuirk",
     "IdentityQuirk",
+    "EvoLinkQuirks",
     "OpenAIReasoningQuirks",
     "OllamaQuirks",
     "OpenRouterQuirks",
@@ -199,12 +200,43 @@ class OpenRouterQuirks:
         return raw
 
 
+class EvoLinkQuirks:
+    """EvoLink OpenAI-compatible gateway.
+
+    Runtime chains use ``evolink/<model>`` so routing, spend attribution, and
+    provider availability remain distinct from direct OpenAI. LiteLLM already
+    knows how to speak OpenAI-compatible chat completions, so the request is
+    translated just before dispatch by setting the OpenAI provider model,
+    EvoLink API base, and EvoLink key.
+    """
+
+    _API_BASE = "https://direct.evolink.ai/v1"
+
+    def transform_model_name(self, name: str) -> str:
+        return name.split("/", 1)[1] if name.startswith("evolink/") else name
+
+    def transform_request(self, payload: dict[str, Any]) -> dict[str, Any]:
+        import os
+
+        out = dict(payload)
+        out["model"] = self.transform_model_name(str(out.get("model", "")))
+        out["api_base"] = self._API_BASE
+        api_key = os.environ.get("EVOLINK_API_KEY")
+        if api_key:
+            out["api_key"] = api_key
+        return out
+
+    def transform_response(self, raw: dict[str, Any]) -> dict[str, Any]:
+        return raw
+
+
 # ── Registry ────────────────────────────────────────────────────────────────
 
 
 _IDENTITY = IdentityQuirk()
 _REGISTRY: dict[str, ProviderQuirk] = {
     "openai": OpenAIReasoningQuirks(),
+    "evolink": EvoLinkQuirks(),
     "ollama": OllamaQuirks(),
     "openrouter": OpenRouterQuirks(),
 }

--- a/src/llm_router/router.py
+++ b/src/llm_router/router.py
@@ -541,6 +541,7 @@ _PROVIDER_KEY_ENV: dict[str, str] = {
     "groq": "GROQ_API_KEY",
     "mistral": "MISTRAL_API_KEY",
     "deepseek": "DEEPSEEK_API_KEY",
+    "evolink": "EVOLINK_API_KEY",
     "fal": "FAL_KEY",
     "replicate": "REPLICATE_API_TOKEN",
     "elevenlabs": "ELEVENLABS_API_KEY",

--- a/tests/test_config_routing_value.py
+++ b/tests/test_config_routing_value.py
@@ -39,6 +39,7 @@ class TestAvailableProviders:
             xai_api_key="",
             cohere_api_key="",
             openrouter_api_key="",
+            evolink_api_key="",
         )
         assert cfg.available_providers == set()
 
@@ -115,6 +116,26 @@ class TestAvailableProviders:
         cfg = RouterConfig(openai_api_key="sk-openai", ollama_base_url="")
         assert "openai" in cfg.text_providers
         assert "openai" in cfg.media_providers
+
+    def test_evolink_key_exposes_text_provider(self):
+        cfg = RouterConfig(evolink_api_key="evl-test", ollama_base_url="")
+
+        assert "evolink" in cfg.available_providers
+        assert "evolink" in cfg.text_providers
+        assert "evolink" not in cfg.media_providers
+
+    def test_apply_keys_to_env_exports_evolink_key(self):
+        original_key = os.environ.get("EVOLINK_API_KEY")
+        try:
+            os.environ.pop("EVOLINK_API_KEY", None)
+            cfg = RouterConfig(evolink_api_key="evl-secret", ollama_base_url="")
+            cfg.apply_keys_to_env()
+            assert os.environ.get("EVOLINK_API_KEY") == "evl-secret"
+        finally:
+            if original_key is not None:
+                os.environ["EVOLINK_API_KEY"] = original_key
+            else:
+                os.environ.pop("EVOLINK_API_KEY", None)
 
 
 class TestClaudeSubscriptionMode:

--- a/tests/test_provider_quirks.py
+++ b/tests/test_provider_quirks.py
@@ -10,6 +10,7 @@ here.
 from __future__ import annotations
 
 from llm_router.provider_quirks import (
+    EvoLinkQuirks,
     IdentityQuirk,
     OllamaQuirks,
     OpenAIReasoningQuirks,
@@ -145,6 +146,24 @@ class TestOpenRouterQuirks:
         assert q.transform_request(payload) is payload
 
 
+class TestEvoLinkQuirks:
+    """EvoLink uses an OpenAI-compatible endpoint while keeping its provider prefix."""
+
+    def test_translates_model_to_openai_compatible_dispatch(self, monkeypatch):
+        monkeypatch.setenv("EVOLINK_API_KEY", "evl-secret")
+        q = EvoLinkQuirks()
+
+        out = q.transform_request({"model": "evolink/gpt-5.2", "temperature": 0.5})
+
+        assert out["model"] == "gpt-5.2"
+        assert out["api_base"] == "https://direct.evolink.ai/v1"
+        assert out["api_key"] == "evl-secret"
+        assert out["temperature"] == 0.5
+
+    def test_transform_model_name_accepts_bare_model(self):
+        assert EvoLinkQuirks().transform_model_name("gpt-5.2") == "gpt-5.2"
+
+
 # ── Registry ────────────────────────────────────────────────────────────────
 
 
@@ -155,6 +174,7 @@ class TestRegistry:
         """openai/ollama/openrouter come pre-wired."""
         names = registered_providers()
         assert "openai" in names
+        assert "evolink" in names
         assert "ollama" in names
         assert "openrouter" in names
 


### PR DESCRIPTION
## Summary
- add `EVOLINK_API_KEY` / `evolink` provider discovery in router config
- route `evolink/<model>` through LiteLLM's OpenAI-compatible transport at `https://direct.evolink.ai/v1`
- add `evolink/gpt-5.2` to the standard text fallback chains
- surface `EVOLINK_API_KEY` in provider auth-error guidance

## Validation
- `uv run --extra dev python -m pytest tests/test_config_routing_value.py tests/test_provider_quirks.py tests/test_routing_value.py tests/test_standard_policy_mirror.py -q`
- Live routed call through `llm_router.providers.call_llm('evolink/gpt-5.2', ...)` returned `evolink-router-ok` with provider `evolink`
- `git diff --check`
