### PR TITLE
13.0.3 — fix the MCP command that could never resolve (#41, #43)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,12 +7,12 @@
     {
       "name": "llm-router",
       "description": "Route text, image, video, and audio tasks to 20+ AI providers with smart routing, budget control, and multi-step orchestration",
-      "version": "13.0.2",
+      "version": "13.0.3",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"
       }
     }
   ],
-  "version": "13.0.2"
+  "version": "13.0.3"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.0.2",
+  "version": "13.0.3",
   "description": "Smart LLM routing with Claude subscription monitoring, complexity-first model selection, and 20+ AI providers",
   "author": {
     "name": "ypollak2",

--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Yali Pollak"
   },
-  "version": "13.0.2",
+  "version": "13.0.3",
   "plugins": [
     {
       "name": "llm-router",
       "description": "Route every Codex task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy.",
-      "version": "13.0.2",
+      "version": "13.0.3",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.0.2",
+  "version": "13.0.3",
   "description": "Route every Codex task to the cheapest capable model \u2014 Gemini Flash, Haiku, Ollama, Perplexity, and 20+ providers. Tracks cross-session savings, enforces routing policy.",
   "author": {
     "name": "ypollak2",

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Yali Pollak"
   },
-  "version": "13.0.2",
+  "version": "13.0.3",
   "plugins": [
     {
       "name": "llm-router",
       "description": "Route every Droid task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy, and sends weekly Slack digests.",
-      "version": "13.0.2",
+      "version": "13.0.3",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.0.2",
+  "version": "13.0.3",
   "description": "Route every Droid task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy, and sends weekly Slack digests.",
   "author": {
     "name": "ypollak2",

--- a/.kimi/mcp.json
+++ b/.kimi/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "llm_router": {
-      "command": "llm_router",
+      "command": "llm-router",
       "args": []
     }
   }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -2,7 +2,7 @@
   "servers": {
     "llm_router": {
       "type": "stdio",
-      "command": "llm_router",
+      "command": "llm-router",
       "args": []
     }
   }

--- a/.windsurf/mcp.json
+++ b/.windsurf/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "llm_router": {
-      "command": "llm_router",
+      "command": "llm-router",
       "args": []
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Nothing yet._
 
+## [13.0.3] — The MCP command that could never resolve (2026-08-26)
+
+Fixes GH#41 and GH#43, and four defects found while reproducing GH#42.
+
+### The entry point (#41)
+
+- **Every MCP registration named a command that does not exist.** `[project.scripts]`
+  declares only the hyphenated `llm-router`, so `shutil.which("llm_router")` returned
+  `None` on *every* install type — pipx, pip and uv alike. Thirty call sites depended on
+  it. The Claude Desktop and claw-code paths fell back to the literal string
+  `"llm_router"`; the main registration fell back to
+  `uv run --directory <site-packages>`, which is what produced `CONNECTION_CLOSED` on a
+  clean pipx install of 13.0.2. Every pull integration — VS Code, Cursor, Windsurf, Kimi,
+  Gemini CLI, Copilot CLI, OpenCode, OpenClaw, Trae, Pi, Codex — was registered dead the
+  same way, along with three configs committed in this repo.
+
+- **`doctor` reported 0 issues while the server was dead.** Every MCP check asked only
+  whether the key `llm_router` was present in `mcpServers`; none read the command back.
+  It now verifies the registered command exists, is executable, and — for
+  `uv run --directory DIR` — that `DIR` is a real project root.
+
+- **Both IDE config templates were invalid JSON.** `localize()` rewrites tool names to the
+  1.0 surface (`llm_code` → `llm(task="code")`) and was running that substitution over a
+  raw JSON document, injecting unescaped quotes into the `"description"` string. Since the
+  templates are written verbatim, `install --ide` produced `.vscode/mcp.json` and
+  `.windsurf/mcp.json` that no IDE could parse. Both are now built with `json.dumps`.
+
+### The security disclosure (#43)
+
+- **`LLM_ROUTER_DIRECT_EXECUTION` is now documented in README.md.** #36 was closed by
+  writing it up in `SECURITY.md`, which the sdist excludes — so for anyone installing from
+  PyPI the entire disclosure was invisible: a default-on feature handing a local model
+  `write_file`/`edit_file`/`run_command` unsupervised, with no shipped text naming it or
+  its off switch. A test now asserts the disclosure survives into the built artifacts.
+
+### Install/uninstall symmetry (#42)
+
+The two behaviours reported already had fixes in the 13.0.2 tag, and the published sdist
+is byte-identical to that tag, so the report could not be reproduced as written. Asserting
+the real contract — install then uninstall is a no-op on every config file — surfaced four
+genuine defects instead:
+
+- **An unguarded `unlink()` aborted uninstall partway through.** One `OSError` in the
+  hook-removal loop (or on the rules file) raised straight out of `uninstall()`, so the
+  statusLine restore and Claude Desktop deregistration — both later in the function —
+  silently never ran. This is the most likely root cause of #42.
+- **An empty `hooks` scaffold was left behind** for users who had no `hooks` section.
+- **`~/.claude.json` was left as a `{"mcpServers": {}}` husk.** It is now recorded as
+  `created_file` and removed only when install is the sole reason the file exists.
+- **`settings.json.bak` held POST-install state**, so restoring it reinstated the very
+  hooks a user was trying to remove. The snapshot is now taken before the first mutation.
+
+### Packaging
+
+- **`_quarantined_tests/` no longer ships to PyPI.** The exclude list anchored `/tests/`;
+  the quarantine lives at the repo root, so 13.0.2 shipped 16 files of dead test code.
+
+### Fixed
+
+- **`KIMI.md` gained a duplicate routing block on every install.** The idempotence guard
+  tested for `llm_router`, a token the block it writes never contains.
+
 ## [13.0.2] — Document what `LLM_ROUTER_DIRECT_EXECUTION` actually grants (2026-08-19)
 
 Documentation and a test. No behaviour change.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="https://pypi.org/project/llm-routing/"><img src="https://img.shields.io/badge/python-3.11+-3572A5?style=flat-square" alt="Python"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-10B981?style=flat-square" alt="License"></a>
   <a href="https://github.com/ypollak2/llm-router/discussions"><img src="https://img.shields.io/github/discussions/ypollak2/llm-router?style=flat-square&color=8B5CF6&label=discussions" alt="Discussions"></a>
-  <a href="https://github.com/RouteWorks/RouterArena"><img src="https://img.shields.io/badge/RouterArena-%238-F59E0B?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyTDMgN2w5IDUgOS01LTktNXpNMyAxN2w5IDUgOS01TTMgMTJsOSA1IDktNSIvPjwvc3ZnPg==" alt="RouterArena #8"></a>
+  <a href="https://github.com/RouteWorks/RouterArena"><img src="https://img.shields.io/badge/RouterArena-listed-F59E0B?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyTDMgN2w5IDUgOS01LTktNXpNMyAxN2w5IDUgOS01TTMgMTJsOSA1IDktNSIvPjwvc3ZnPg==" alt="Listed on RouterArena"></a>
   <a href="https://mcptoplist.com/server/glama%2Fypollak2%2Fllm-router"><img src="https://mcptoplist.com/badge/glama%2Fypollak2%2Fllm-router.svg" alt="MCP Toplist: Top 1% of 98,291" /></a>
 </p>
 
@@ -62,7 +62,7 @@ pip install llm-routing   # PyPI name is llm-routing; the CLI command is llm-rou
 <summary><b>📑 Table of Contents</b></summary>
 
 - [Why People Install This](#why-people-install-this)
-- [Ranked #8 on RouterArena](#ranked-8-on-routerarena)
+- [On the RouterArena leaderboard](#on-the-routerarena-leaderboard)
 - [Quick Start](#quick-start)
 - [Example Routing](#example-routing)
 - [Works With](#works-with)
@@ -107,9 +107,9 @@ You keep the same workflow. The router changes the model choice underneath.
 
 ---
 
-## Ranked #8 on RouterArena
+## On the RouterArena leaderboard
 
-`llm-router` was independently benchmarked and ranked **#8** on [RouterArena](https://github.com/RouteWorks/RouterArena) — a community leaderboard that evaluates model routers on routing accuracy, latency, cost efficiency, and fallback reliability.
+`llm-router` is independently benchmarked on [RouterArena](https://github.com/RouteWorks/RouterArena), a community leaderboard that scores model routers on an accuracy-versus-cost curve, plus optimality, robustness and latency. Rank moves as new routers land — see the [live leaderboard](https://github.com/RouteWorks/RouterArena#leaderboard) for the current standing.
 
 ---
 
@@ -348,7 +348,36 @@ llm-router runs entirely on your machine. There is no hosted proxy, no telemetry
 - Usage logs (SQLite) are not encrypted at rest — use full-disk encryption if needed
 - The router cannot prevent model jailbreaks or prompt injection at the provider level
 
-See [SECURITY.md](SECURITY.md) for responsible disclosure policy.
+### `LLM_ROUTER_DIRECT_EXECUTION` — read this before your first run
+
+**This is on by default.** When enabled, `hooks/auto-route.py` tries to answer a prompt
+locally before Claude Code sees it. For prompts it classifies as needing file work, it runs
+a tool-calling agent loop that hands the local model three tools — `write_file`, `edit_file`
+and `run_command` — **unsupervised, with no confirmation step**, for up to 15 iterations.
+`run_command` executes through a shell.
+
+What is actually enforced:
+
+- `write_file` / `edit_file` are confined to the project root. This works as described.
+- `run_command` is filtered by a small regex blocklist of top-level destructive patterns.
+
+What that blocklist does **not** stop (measured, not estimated): targeted deletes inside the
+project (`rm -rf ./src`), `$HOME` deletes via shell expansion, `git push --force`,
+`git reset --hard`, arbitrary `npm`/`pip install`, reads outside the project
+(`cat ../../.ssh/id_rsa`), network exfiltration (`curl -X POST … -d @.env`), and echoing
+API keys. It stops catastrophic *system* damage — not project damage, credential
+disclosure, or exfiltration.
+
+**Turn it off:**
+
+```bash
+export LLM_ROUTER_DIRECT_EXECUTION=false
+```
+
+Routing still works with it disabled; you lose only the local pre-answer path.
+
+See [SECURITY.md](https://github.com/ypollak2/llm-router/blob/main/SECURITY.md) for the full
+analysis and the responsible disclosure policy.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-routing"
-version = "13.0.2"
+version = "13.0.3"
 description = "Multi-LLM router MCP server — smart complexity routing, budget-aware model selection, 20+ providers (Claude, OpenAI, Gemini, Ollama, etc.)"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,11 @@ exclude = [
     "/skills/",
     "/submissions/",
     "/tests/",
+    # The quarantine lives at the repo ROOT, not under tests/, so the "/tests/"
+    # entry never covered it and 13.0.2 shipped 16 files of dead, uncollectable
+    # test code to PyPI. Same anchoring lesson as the block above, inverted:
+    # there the pattern matched too much, here it matched too little.
+    "/_quarantined_tests/",
     "/awesome-readme/",
     # ── Backup / temp files — never publish (CLAUDE.md sdist safety rule) ─
     ".env.backup.*",

--- a/src/llm_router/cli.py
+++ b/src/llm_router/cli.py
@@ -477,16 +477,36 @@ Call the relevant tool BEFORE generating your own answer — relay the routed re
 
 Never skip routing for non-trivial tasks. LLM Router routes to the cheapest capable model.
 """)
+    # The guard must look for something the block ACTUALLY contains. It used to
+    # test for "llm_router", a token that appears nowhere in kimi_rules — the
+    # text says "LLM Router" with a space throughout, and localize() rewrites
+    # the tool names to llm(task="…"). So the guard was always true and every
+    # install appended another copy; the committed KIMI.md in this repo reached
+    # 53 of them. Anchor on the section heading instead, which is part of the
+    # written text and therefore cannot drift away from it.
+    _KIMI_MARKER = "## LLM Router routing"
     if kimi_md.exists():
         content = kimi_md.read_text()
-        if "llm_router" not in content.lower():
+        if _KIMI_MARKER not in content:
             kimi_md.write_text(content + kimi_rules)
             actions.append(f"Appended: LLM Router routing rules to {kimi_md}")
+            # It also recorded nothing, so uninstall had no way to strip what it
+            # wrote and every copy survived `llm_router uninstall`.
+            try:
+                from llm_router import install_manifest
+                install_manifest.record("text_block", kimi_md, block=kimi_rules)
+            except Exception:
+                pass  # a manifest write must never break install
         else:
             actions.append(f"Skipped: {kimi_md} already has LLM Router rules")
     else:
         kimi_md.write_text(f"# Project Instructions\n{kimi_rules}")
         actions.append(f"Created: {kimi_md} with LLM Router routing rules")
+        try:
+            from llm_router import install_manifest
+            install_manifest.record("created_file", kimi_md, block=kimi_rules)
+        except Exception:
+            pass
 
     actions.append(
         "NOTE (pull routing): Kimi Code has no UserPromptSubmit hook. "

--- a/src/llm_router/cli.py
+++ b/src/llm_router/cli.py
@@ -87,7 +87,7 @@ def _merge_json_mcp_block(
     Args:
         config_path: Path to JSON config file
         server_name: Name of MCP server (e.g., "llm_router")
-        config_dict: Server config dict (e.g., {"command": "llm_router"})
+        config_dict: Server config dict (e.g., {"command": "llm-router"})
         root_key: Root key for servers (default "mcpServers", VS Code uses "servers")
 
     Returns:
@@ -207,7 +207,7 @@ def _install_vscode_files() -> list[str]:
         _merge_json_mcp_block(
             user_mcp,
             "llm_router",
-            {"type": "stdio", "command": "llm_router", "args": []},
+            {"type": "stdio", "command": "llm-router", "args": []},
             root_key="servers",
         )
     )
@@ -219,7 +219,7 @@ def _install_vscode_files() -> list[str]:
         _merge_json_mcp_block(
             workspace_mcp,
             "llm_router",
-            {"type": "stdio", "command": "llm_router", "args": []},
+            {"type": "stdio", "command": "llm-router", "args": []},
             root_key="servers",
         )
     )
@@ -261,7 +261,7 @@ def _install_cursor_files() -> list[str]:
         _merge_json_mcp_block(
             mcp_json,
             "llm_router",
-            {"command": "llm_router", "args": []},
+            {"command": "llm-router", "args": []},
             root_key="mcpServers",
         )
     )
@@ -284,7 +284,7 @@ def _install_opencode_files() -> list[str]:
         _merge_json_mcp_block(
             config,
             "llm_router",
-            {"command": "llm_router", "args": []},
+            {"command": "llm-router", "args": []},
         )
     )
 
@@ -306,7 +306,7 @@ def _install_gemini_cli_files() -> list[str]:
         _merge_json_mcp_block(
             settings,
             "llm_router",
-            {"command": "llm_router", "args": []},
+            {"command": "llm-router", "args": []},
         )
     )
 
@@ -351,7 +351,7 @@ def _install_copilot_cli_files() -> list[str]:
         _merge_json_mcp_block(
             mcp_json,
             "llm_router",
-            {"command": "llm_router", "args": []},
+            {"command": "llm-router", "args": []},
         )
     )
 
@@ -380,7 +380,7 @@ def _install_windsurf_files() -> list[str]:
         _merge_json_mcp_block(
             mcp_json,
             "llm_router",
-            {"command": "llm_router", "args": []},
+            {"command": "llm-router", "args": []},
             root_key="mcpServers",
         )
     )
@@ -392,7 +392,7 @@ def _install_windsurf_files() -> list[str]:
         _merge_json_mcp_block(
             workspace_mcp,
             "llm_router",
-            {"command": "llm_router", "args": []},
+            {"command": "llm-router", "args": []},
             root_key="mcpServers",
         )
     )
@@ -434,7 +434,7 @@ def _install_kimi_files() -> list[str]:
         _merge_json_mcp_block(
             global_mcp,
             "llm_router",
-            {"command": "llm_router", "args": [], "description": (
+            {"command": "llm-router", "args": [], "description": (
                 "LLM Router smart LLM router — routes tasks to the cheapest capable model. "
                 "Call before answering to route to a cheaper capable model."
             )},
@@ -449,7 +449,7 @@ def _install_kimi_files() -> list[str]:
         _merge_json_mcp_block(
             workspace_mcp,
             "llm_router",
-            {"command": "llm_router", "args": []},
+            {"command": "llm-router", "args": []},
             root_key="mcpServers",
         )
     )
@@ -508,7 +508,7 @@ def _install_openclaw_files() -> list[str]:
         _merge_json_mcp_block(
             mcp_json,
             "llm_router",
-            {"command": "llm_router", "args": []},
+            {"command": "llm-router", "args": []},
         )
     )
 
@@ -530,7 +530,7 @@ def _install_trae_files() -> list[str]:
         _merge_json_mcp_block(
             mcp_json,
             "llm_router",
-            {"command": "llm_router", "args": []},
+            {"command": "llm-router", "args": []},
         )
     )
 
@@ -553,7 +553,7 @@ def _install_pi_files() -> list[str]:
             mcp_json,
             "llm_router",
             {
-                "command": "llm_router",
+                "command": "llm-router",
                 "args": [],
                 "lifecycle": "lazy",
             },
@@ -578,7 +578,7 @@ def _install_codex_cli_files() -> list[str]:
         _merge_json_mcp_block(
             config_json,
             "llm_router",
-            {"command": "llm_router", "args": []},
+            {"command": "llm-router", "args": []},
         )
     )
 
@@ -594,7 +594,7 @@ def _print_claude_desktop_config() -> list[str]:
     config = {
         "mcpServers": {
             "llm_router": {
-                "command": "llm_router",
+                "command": "llm-router",
                 "args": []
             }
         }
@@ -609,7 +609,7 @@ def _print_vs_code_copilot_config() -> list[str]:
     config = {
         "servers": {
             "llm_router": {
-                "command": "llm_router",
+                "command": "llm-router",
                 "args": []
             }
         }

--- a/src/llm_router/commands/doctor.py
+++ b/src/llm_router/commands/doctor.py
@@ -371,6 +371,54 @@ def _render_host_explainer() -> str:
     )
 
 
+def _mcp_command_problems(entry: object, label: str) -> list[str]:
+    """Validate a registered MCP entry can actually START. Returns problems, or [].
+
+    GH#41: every MCP check in this file asked only whether the KEY "llm_router"
+    was present in mcpServers. A pipx install of 13.0.2 had the key, a
+    `uv run --directory <site-packages>` command that could never start, and
+    `claude mcp list` reporting CONNECTION_CLOSED — while doctor printed 0
+    issues. Presence of a registration is not evidence it works; this reads the
+    command back and checks it is runnable.
+    """
+    problems: list[str] = []
+
+    if not isinstance(entry, dict):
+        return [f"{label}: mcpServers.llm_router is {type(entry).__name__}, expected an object"]
+
+    command = entry.get("command")
+    if not command or not isinstance(command, str):
+        return [f"{label}: mcpServers.llm_router has no 'command'"]
+
+    # A bare name must be on PATH; an absolute/relative path must exist and be executable.
+    if os.sep in command:
+        cmd_path = Path(command).expanduser()
+        if not cmd_path.exists():
+            problems.append(f"{label}: command does not exist: {command}")
+        elif not os.access(cmd_path, os.X_OK):
+            problems.append(f"{label}: command is not executable: {command}")
+    elif shutil.which(command) is None:
+        problems.append(f"{label}: command not found on PATH: {command}")
+
+    # `uv run --directory DIR` is only valid against a real project root. This is
+    # the specific shape that shipped broken: DIR was a site-packages path.
+    args = entry.get("args") or []
+    if isinstance(args, list) and "--directory" in args:
+        try:
+            project_dir = Path(args[args.index("--directory") + 1])
+        except IndexError:
+            problems.append(f"{label}: --directory given with no path")
+        else:
+            if not (project_dir / "pyproject.toml").exists():
+                problems.append(
+                    f"{label}: 'uv run --directory {project_dir}' has no pyproject.toml — "
+                    f"this is a packaged install, not a source checkout, so the server "
+                    f"cannot start (CONNECTION_CLOSED)"
+                )
+
+    return problems
+
+
 def _check_savings_posture() -> list[str]:
     """Return rendered status lines for each quota-savings configuration check.
 
@@ -751,7 +799,16 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
             pass
     registered_cc = "llm_router" in settings.get("mcpServers", {})
     if registered_cc:
-        print(_ok("MCP server registered in ~/.claude/settings.json"))
+        # GH#41: registered is not the same as runnable.
+        _cc_problems = _mcp_command_problems(
+            settings["mcpServers"]["llm_router"], "~/.claude/settings.json"
+        )
+        if _cc_problems:
+            for _p in _cc_problems:
+                print(_fail(_p, fix="llm_router install"))
+            issues.extend(_cc_problems)
+        else:
+            print(_ok("MCP server registered in ~/.claude/settings.json"))
     else:
         print(
             _fail(
@@ -776,7 +833,15 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
         try:
             cfg = json.loads(desktop_path.read_text())
             if "llm_router" in cfg.get("mcpServers", {}):
-                print(_ok(f"registered ({desktop_path})"))
+                _dt_problems = _mcp_command_problems(
+                    cfg["mcpServers"]["llm_router"], "Claude Desktop"
+                )
+                if _dt_problems:
+                    for _p in _dt_problems:
+                        print(_fail(_p, fix="llm_router install"))
+                    issues.extend(_dt_problems)
+                else:
+                    print(_ok(f"registered ({desktop_path})"))
             else:
                 print(
                     _fail(

--- a/src/llm_router/commands/install.py
+++ b/src/llm_router/commands/install.py
@@ -275,7 +275,7 @@ def _run_install_headless() -> None:
     print(_dim("  (llm_router install does this automatically; shown for reference)"))
     import json as _json
     example = {
-        "mcpServers": {"llm_router": {"command": "llm_router", "args": []}},
+        "mcpServers": {"llm_router": {"command": "llm-router", "args": []}},
         "hooks": {
             "UserPromptSubmit": [{"matcher": "", "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/llm_router-auto-route.py"}]}],
             "Stop":             [{"matcher": "", "hooks": [{"type": "command", "command": "python3 ~/.claude/hooks/llm_router-session-end.py"}]}],
@@ -309,7 +309,7 @@ _HOST_SNIPPETS: dict[str, str] = {
    mcp:
      servers:
        llm_router:
-         command: llm_router
+         command: llm-router
          args: []
 
 2. Copy routing rules so Codex knows when to call llm_auto:
@@ -331,7 +331,7 @@ Add inside the top-level object:
 
   "mcpServers": {{
     "llm_router": {{
-      "command": "llm_router",
+      "command": "llm-router",
       "args": [],
       "env": {{
         "LLM_ROUTER_PROFILE": "balanced"
@@ -351,7 +351,7 @@ Note: cost-routing is not available in Desktop (no hook system).
    {{
      "servers": {{
        "llm_router": {{
-         "command": "llm_router",
+         "command": "llm-router",
          "args": []
        }}
      }}
@@ -539,7 +539,7 @@ def _install_codex_files(mode: str = "gateway") -> list[str]:
         "\nmcp:\n"
         "  servers:\n"
         "    llm_router:\n"
-        "      command: llm_router\n"
+        "      command: llm-router\n"
         "      args: []\n"
     )
     existing = config_yaml.read_text() if config_yaml.exists() else ""
@@ -804,7 +804,7 @@ def uninstall_host_integrations() -> list[str]:
                 "\nmcp:\n"
                 "  servers:\n"
                 "    llm_router:\n"
-                "      command: llm_router\n"
+                "      command: llm-router\n"
                 "      args: []\n"
             )
             if mcp_block in y:
@@ -928,7 +928,7 @@ def _install_opencode_files() -> list[str]:
     opencode_dir.mkdir(parents=True, exist_ok=True)
 
     # 1. MCP server entry
-    server_entry = {"command": "llm_router", "args": []}
+    server_entry = {"command": "llm-router", "args": []}
     actions += _merge_json_mcp_block(opencode_dir / "config.json", "llm_router", server_entry)
 
     # 2. Hook script
@@ -954,7 +954,7 @@ def _install_gemini_cli_files() -> list[str]:
     gemini_dir.mkdir(parents=True, exist_ok=True)
 
     # 1. MCP server entry in ~/.gemini/settings.json
-    server_entry = {"command": "llm_router", "args": []}
+    server_entry = {"command": "llm-router", "args": []}
     actions += _merge_json_mcp_block(gemini_dir / "settings.json", "llm_router", server_entry)
 
     # 2. Extension manifest + hooks directory
@@ -1086,7 +1086,7 @@ def _install_copilot_cli_files() -> list[str]:
     copilot_dir = home / ".config" / "gh" / "copilot"
     copilot_dir.mkdir(parents=True, exist_ok=True)
 
-    server_entry = {"command": "llm_router", "args": []}
+    server_entry = {"command": "llm-router", "args": []}
     actions += _merge_json_mcp_block(copilot_dir / "mcp.json", "llm_router", server_entry)
 
     # Routing rules → ~/.config/gh/copilot/instructions.md
@@ -1106,7 +1106,7 @@ def _install_openclaw_files() -> list[str]:
     openclaw_dir = home / ".openclaw"
     openclaw_dir.mkdir(parents=True, exist_ok=True)
 
-    server_entry = {"command": "llm_router", "args": []}
+    server_entry = {"command": "llm-router", "args": []}
     actions += _merge_json_mcp_block(openclaw_dir / "mcp.json", "llm_router", server_entry)
     actions += _append_routing_rules(openclaw_dir / "instructions.md", "openclaw-rules.md")
 
@@ -1130,7 +1130,7 @@ def _install_trae_files() -> list[str]:
         trae_dir = home / ".config" / "Trae"
     trae_dir.mkdir(parents=True, exist_ok=True)
 
-    server_entry = {"command": "llm_router", "args": []}
+    server_entry = {"command": "llm-router", "args": []}
     actions += _merge_json_mcp_block(trae_dir / "mcp.json", "llm_router", server_entry)
 
     # .rules file in current project directory (Trae-specific pattern)
@@ -1172,7 +1172,7 @@ def _install_vscode_files() -> list[str]:
     else:
         mcp_json = home / ".config" / "Code" / "User" / "mcp.json"
 
-    server_entry = {"command": "llm_router", "args": []}
+    server_entry = {"command": "llm-router", "args": []}
     actions += _merge_json_mcp_block(mcp_json, "llm_router", server_entry, root_key="servers")
 
     # Append routing guidance to .github/copilot-instructions.md in cwd (if it exists)
@@ -1190,7 +1190,7 @@ def _install_windsurf_files() -> list[str]:
 
     actions: list[str] = []
     mcp_json = pathlib.Path.cwd() / ".windsurf" / "mcp.json"
-    server_entry = {"command": "llm_router", "args": []}
+    server_entry = {"command": "llm-router", "args": []}
     actions += _merge_json_mcp_block(mcp_json, "llm_router", server_entry, root_key="mcpServers")
     return actions
 
@@ -1204,7 +1204,7 @@ def _install_cursor_files() -> list[str]:
 
     # Global Cursor MCP config (applies across all projects)
     mcp_json = home / ".cursor" / "mcp.json"
-    server_entry = {"command": "llm_router", "args": []}
+    server_entry = {"command": "llm-router", "args": []}
     actions += _merge_json_mcp_block(mcp_json, "llm_router", server_entry, root_key="mcpServers")
 
     # Append routing rules to ~/.cursor/rules/llm_router.md

--- a/src/llm_router/install_hooks.py
+++ b/src/llm_router/install_hooks.py
@@ -860,6 +860,22 @@ def install(force: bool = False) -> list[str]:
     """
     actions: list[str] = []
 
+    # ── Snapshot settings.json BEFORE touching it ────────────────────────
+    # This backup used to be taken from the statusLine branch far below, which
+    # runs after the hook registrations and the mcpServers entry have already
+    # been written and saved. `settings.json.bak` therefore held llm_router's
+    # own hooks and MCP server — POST-install state under a pre-install name.
+    # A user who reached for it after a bad install and copied it back would
+    # have silently reinstated every hook they were trying to remove.
+    #
+    # install() always rewrites settings.json, so the snapshot is taken
+    # unconditionally here. _backup_before_overwrite never clobbers an existing
+    # .bak, so the first capture is preserved and later runs get timestamped
+    # copies.
+    _settings_backup: Path | None = None
+    if _SETTINGS_PATH.exists():
+        _settings_backup = _backup_before_overwrite(_SETTINGS_PATH)
+
     # ── Copy hook scripts ────────────────────────────────────────────────
     _HOOKS_DST.mkdir(parents=True, exist_ok=True)
     actions.extend(_sync_hook_support_files())  # CHZ-SURF-01
@@ -1044,7 +1060,12 @@ def install(force: bool = False) -> list[str]:
                         previous=current_sl,
                     )
                     if current_sl is not None:
-                        _b = _backup_before_overwrite(_SETTINGS_PATH)
+                        # Point at the snapshot taken at the TOP of install(),
+                        # rather than capturing a fresh one here — by this line
+                        # settings.json already carries llm_router's own hooks
+                        # and MCP entry, so a backup taken now is not a backup
+                        # of anything the user would want restored.
+                        _b = _settings_backup
                         _where = f"; backup at {_b.name}" if _b else ""
                         actions.append(
                             "WARNING: replacing an existing statusLine in "

--- a/src/llm_router/install_hooks.py
+++ b/src/llm_router/install_hooks.py
@@ -667,7 +667,11 @@ def _install_claude_code_cli(mcp_entry: dict) -> list[str]:
     # Direct JSON merge fallback (works without the claude CLI — Docker/CI/headless)
     try:
         data: dict = {}
-        if _CLAUDE_JSON_PATH.exists():
+        # GH#42: remember whether WE created this file. Uninstall previously left
+        # behind a `{"mcpServers": {}}` husk for users who never had a
+        # ~/.claude.json — residue from a tool they had just removed.
+        _preexisting = _CLAUDE_JSON_PATH.exists()
+        if _preexisting:
             try:
                 data = json.loads(_CLAUDE_JSON_PATH.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
@@ -677,6 +681,12 @@ def _install_claude_code_cli(mcp_entry: dict) -> list[str]:
             return ["MCP server already in ~/.claude.json: llm_router"]
         servers["llm_router"] = mcp_entry
         _CLAUDE_JSON_PATH.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        if not _preexisting:
+            try:
+                from llm_router import install_manifest as _im
+                _im.record("created_file", _CLAUDE_JSON_PATH)
+            except Exception:
+                pass  # a manifest write must never break install
         return ["Registered llm_router MCP server in ~/.claude.json (direct merge)"]
     except OSError as e:
         return [f"WARNING: could not register MCP in ~/.claude.json: {e}"]
@@ -705,10 +715,60 @@ def _uninstall_claude_code_cli() -> list[str]:
         if "llm_router" not in data.get("mcpServers", {}):
             return []
         del data["mcpServers"]["llm_router"]
+        # GH#42: prune the empty container too, and drop the file entirely when
+        # install is the only reason it exists. An empty mcpServers map holds no
+        # information; leaving it is residue, not caution.
+        if not data["mcpServers"]:
+            del data["mcpServers"]
+        if not data:
+            from llm_router import install_manifest as _im
+            if _im.find("created_file", _CLAUDE_JSON_PATH) is not None:
+                _CLAUDE_JSON_PATH.unlink()
+                return [f"Removed {_CLAUDE_JSON_PATH} (created by install)"]
         _CLAUDE_JSON_PATH.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
         return ["Removed llm_router from ~/.claude.json"]
     except OSError:
         return []
+
+
+def _router_bin() -> str | None:
+    """Locate the installed llm-router console script.
+
+    GH#41: `[project.scripts]` declares only the HYPHENATED `llm-router`, so
+    `shutil.which("llm_router")` never matched on ANY install type — pipx, pip
+    or uv. The underscore is still tried second so a dev checkout that exposes
+    a legacy alias keeps working.
+    """
+    return shutil.which("llm-router") or shutil.which("llm_router")
+
+
+def _build_mcp_entry() -> tuple[dict | None, list[str]]:
+    """Build the MCP server entry, or (None, warnings) if it cannot be resolved.
+
+    GH#41: the old code fell back to `uv run --directory <dir>` whenever the
+    binary lookup failed. Because the lookup ALWAYS failed, every packaged
+    install got a uv invocation pointed at its site-packages directory, which
+    is not a project root — hence CONNECTION_CLOSED. The uv fallback is now
+    gated on actually being a source checkout, and an unresolvable binary
+    warns instead of writing a command that cannot run.
+    """
+    router_bin = _router_bin()
+    if router_bin:
+        return {"command": router_bin, "args": []}, []
+
+    project_dir = _PACKAGE_DIR.parent.parent
+    uv_path = shutil.which("uv")
+    if uv_path and (project_dir / "pyproject.toml").exists():
+        return {
+            "command": uv_path,
+            "args": ["run", "--directory", str(project_dir), "llm-router"],
+        }, []
+
+    return None, [
+        "WARN could not locate the 'llm-router' executable; skipping MCP "
+        "registration. Ensure the install's bin directory is on PATH "
+        "(pipx: `pipx ensurepath`), then re-run `llm-router install`."
+    ]
 
 
 def _install_claude_desktop() -> list[str]:
@@ -720,8 +780,9 @@ def _install_claude_desktop() -> list[str]:
     if config_path is None:
         return ["SKIP Claude Desktop: unsupported platform"]
 
-    llm_router_bin = shutil.which("llm_router") or "llm_router"
-    entry = {"command": llm_router_bin, "args": []}
+    entry, warnings = _build_mcp_entry()
+    if entry is None:
+        return warnings
 
     config = _load_desktop_config(config_path)
     servers = config.setdefault("mcpServers", {})
@@ -874,26 +935,26 @@ def install(force: bool = False) -> list[str]:
     # ── Register MCP server globally ─────────────────────────────────────
     # Build the entry using the installed llm_router binary when available
     # (pip install), falling back to uv run for development installs.
-    llm_router_bin = shutil.which("llm_router")
-    if llm_router_bin:
-        mcp_entry: dict = {"command": llm_router_bin, "args": []}
-    else:
-        uv_path = shutil.which("uv") or "uv"
-        project_dir = str(_PACKAGE_DIR.parent.parent)
-        mcp_entry = {"command": uv_path, "args": ["run", "--directory", project_dir, "llm_router"]}
+    mcp_entry, _mcp_warnings = _build_mcp_entry()
+    actions.extend(_mcp_warnings)
 
-    # ~/.claude/settings.json — Claude Desktop / interactive Claude Code
-    settings2 = _load_settings()
-    mcp_servers = settings2.setdefault("mcpServers", {})
-    if "llm_router" not in mcp_servers:
-        mcp_servers["llm_router"] = mcp_entry
-        _save_settings(settings2)
-        actions.append("Registered llm_router MCP server in ~/.claude/settings.json")
+    # GH#41: skip registration entirely rather than write a command that cannot
+    # resolve. A missing server is diagnosable; a dead one reports CONNECTION_CLOSED.
+    if mcp_entry is None:
+        actions.append("SKIP MCP registration — no runnable llm-router command")
     else:
-        actions.append("MCP server already in ~/.claude/settings.json: llm_router")
+        # ~/.claude/settings.json — Claude Desktop / interactive Claude Code
+        settings2 = _load_settings()
+        mcp_servers = settings2.setdefault("mcpServers", {})
+        if "llm_router" not in mcp_servers:
+            mcp_servers["llm_router"] = mcp_entry
+            _save_settings(settings2)
+            actions.append("Registered llm_router MCP server in ~/.claude/settings.json")
+        else:
+            actions.append("MCP server already in ~/.claude/settings.json: llm_router")
 
-    # ~/.claude.json — Claude Code CLI (`claude -p`, non-interactive, agent mode)
-    actions.extend(_install_claude_code_cli(mcp_entry))
+        # ~/.claude.json — Claude Code CLI (`claude -p`, non-interactive, agent mode)
+        actions.extend(_install_claude_code_cli(mcp_entry))
 
     # ── Copy routing rules ───────────────────────────────────────────────
     _RULES_DST.mkdir(parents=True, exist_ok=True)
@@ -1027,8 +1088,17 @@ def uninstall() -> list[str]:
         dst = _HOOKS_DST / dst_name
 
         if dst.exists():
-            dst.unlink()
-            actions.append(f"Removed {dst}")
+            # GH#42: this unlink was unguarded. A single OSError here — a
+            # permission problem, a file held open, a read-only mount — aborted
+            # uninstall() partway through, so everything AFTER this loop (the
+            # statusLine restore, the Claude Desktop deregistration, the sidecar
+            # cleanup) silently never ran. The user sees "uninstall left things
+            # behind" with no error explaining why. Report and keep going.
+            try:
+                dst.unlink()
+                actions.append(f"Removed {dst}")
+            except OSError as e:
+                actions.append(f"WARN could not remove {dst}: {e}")
 
         legacy_msg = _remove_legacy_hook_alias(_HOOKS_DST, src_name, dst_name)
         if legacy_msg:
@@ -1052,6 +1122,21 @@ def uninstall() -> list[str]:
             hooks[event] = filtered
             actions.append(f"Unregistered {event} hook: {dst_name}")
 
+    # GH#42: prune the scaffold, not just its contents. The loop above empties
+    # each event list but leaves the keys, so a user who had no "hooks" section
+    # before install was left with
+    #   "hooks": {"SessionStart": [], "UserPromptSubmit": [], ...}
+    # after uninstall — residue from a tool they just removed. An empty event
+    # list carries no information, and an empty "hooks" map carries none either;
+    # anything the user owns has entries and survives untouched.
+    _hooks = settings.get("hooks")
+    if isinstance(_hooks, dict):
+        for _event in [k for k, v in _hooks.items() if isinstance(v, list) and not v]:
+            del _hooks[_event]
+        if not _hooks:
+            del settings["hooks"]
+            actions.append("Removed empty hooks section from settings.json")
+
     _save_settings(settings)
 
     # Remove MCP server registration (settings.json + .claude.json)
@@ -1066,8 +1151,13 @@ def uninstall() -> list[str]:
     # Remove rules
     rules_dst = _RULES_DST / "llm_router.md"
     if rules_dst.exists():
-        rules_dst.unlink()
-        actions.append(f"Removed {rules_dst}")
+        # GH#42: unguarded, same as the hook unlink above — one OSError here
+        # aborted every remaining cleanup step.
+        try:
+            rules_dst.unlink()
+            actions.append(f"Removed {rules_dst}")
+        except OSError as e:
+            actions.append(f"WARN could not remove {rules_dst}: {e}")
 
     # RED2-4-01: also remove PRE-REBRAND "llm-router" artifacts that earlier
     # versions installed under the old identity. They are never referenced by the
@@ -1093,8 +1183,12 @@ def uninstall() -> list[str]:
         try:
             statusline_dst.unlink()
             actions.append(f"Removed {statusline_dst}")
-        except OSError:
-            pass
+        except OSError as e:
+            # GH#42: this was `except OSError: pass`. A failure here leaves the
+            # script on disk while uninstall reports success, which is exactly
+            # how "uninstall left things behind" stays invisible to the user
+            # and unreproducible for us.
+            actions.append(f"WARN could not remove statusline script {statusline_dst}: {e}")
     settings_sl = _load_settings()
     current_sl = settings_sl.get("statusLine")
     if isinstance(current_sl, dict) and "llm_router-statusline.sh" in str(
@@ -1231,8 +1325,10 @@ def install_claw_code() -> list[str]:
         actions.append(f"WARN could not write {env_path}: {e}")
 
     # ── Register MCP server in claw-code settings ────────────────────────
-    llm_router_bin = shutil.which("llm_router") or "llm_router"
-    mcp_entry = {"command": llm_router_bin, "args": []}
+    mcp_entry, _mcp_warnings = _build_mcp_entry()
+    if mcp_entry is None:
+        return actions + _mcp_warnings
+    actions.extend(_mcp_warnings)
     mcp_servers = settings.setdefault("mcpServers", {})
     if "llm_router" not in mcp_servers:
         mcp_servers["llm_router"] = mcp_entry

--- a/src/llm_router/install_hooks.py
+++ b/src/llm_router/install_hooks.py
@@ -1424,30 +1424,50 @@ def uninstall_claw_code() -> list[str]:
 
 # ── IDE config installation (pull-routing: VS Code/Copilot, Windsurf, Cursor) ──
 
-_VSCODE_MCP_CONTENT = localize("""\
-{
-  "servers": {
-    "llm_router": {
-      "type": "stdio",
-      "command": "llm_router",
-      "args": [],
-      "description": "LLM Router smart LLM router — routes tasks to the cheapest capable model (Ollama → Gemini Flash → GPT-4o-mini → Claude). Call llm_code for coding tasks, llm_query for questions, llm_analyze for analysis, llm_research for web search. Each call routes to a cheaper capable model before using Claude quota."
-    }
-  }
-}
-""")
+# GH#41: the command is the HYPHENATED console script. `llm_router` is not one
+# — see _router_bin(). These files are written verbatim to a user's project, so
+# they must also be VALID JSON, and they were not: localize() rewrites the old
+# tool names to the 1.0 surface (`llm_code` → `llm(task="code")`), and running
+# that over a raw JSON document injected unescaped double quotes straight into
+# the "description" string literal. Building the document with json.dumps means
+# the description is escaped by the serializer and cannot corrupt the file,
+# whatever localize() substitutes into it.
+_MCP_DESCRIPTION = localize(
+    "LLM Router smart LLM router — routes tasks to the cheapest capable model "
+    "(Ollama → Gemini Flash → GPT-4o-mini → Claude). Call llm_code for coding "
+    "tasks, llm_query for questions, llm_analyze for analysis, llm_research for "
+    "web search. Each call routes to a cheaper capable model before using "
+    "Claude quota."
+)
 
-_WINDSURF_MCP_CONTENT = localize("""\
-{
-  "mcpServers": {
-    "llm_router": {
-      "command": "llm_router",
-      "args": [],
-      "description": "LLM Router smart LLM router — routes tasks to the cheapest capable model (Ollama → Gemini Flash → GPT-4o-mini → Claude). Call llm_code for coding tasks, llm_query for questions, llm_analyze for analysis, llm_research for web search. Each call routes to a cheaper capable model before using Claude quota."
-    }
-  }
-}
-""")
+_VSCODE_MCP_CONTENT = json.dumps(
+    {
+        "servers": {
+            "llm_router": {
+                "type": "stdio",
+                "command": "llm-router",
+                "args": [],
+                "description": _MCP_DESCRIPTION,
+            }
+        }
+    },
+    indent=2,
+    ensure_ascii=False,
+) + "\n"
+
+_WINDSURF_MCP_CONTENT = json.dumps(
+    {
+        "mcpServers": {
+            "llm_router": {
+                "command": "llm-router",
+                "args": [],
+                "description": _MCP_DESCRIPTION,
+            }
+        }
+    },
+    indent=2,
+    ensure_ascii=False,
+) + "\n"
 
 _CURSOR_RULE_CONTENT = localize("""\
 ---

--- a/tests/audit/test_installer_other_hosts.py
+++ b/tests/audit/test_installer_other_hosts.py
@@ -85,7 +85,7 @@ def test_opencode_install_only_registers_mcp_server(monkeypatch, tmp_path):
     _assert_json_has_no_forced_default_keys(config_json)
     data = json.loads(config_json.read_text())
     assert set(data.keys()) == {"mcpServers"}
-    assert data["mcpServers"]["llm_router"] == {"command": "llm_router", "args": []}
+    assert data["mcpServers"]["llm_router"] == {"command": "llm-router", "args": []}
     assert any("llm_router MCP server" in a for a in actions)
 
 
@@ -250,7 +250,7 @@ def test_vscode_install_only_registers_mcp_server_under_servers_key(monkeypatch,
     found = _DANGEROUS_TOP_LEVEL_KEYS & set(data.keys())
     assert not found, f"VS Code mcp.json has forced-default keys: {found}"
     assert set(data.keys()) == {"servers"}
-    assert data["servers"]["llm_router"] == {"command": "llm_router", "args": []}
+    assert data["servers"]["llm_router"] == {"command": "llm-router", "args": []}
 
 
 # ── Cursor IDE ────────────────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -874,18 +874,58 @@ _CWD_INSTALL_TARGETS = (
     ".github/copilot-instructions.md",
 )
 
+# The same defect, one blast radius larger. `TestInstallHost` in
+# test_cost_host.py called the real `_install_host("all")` with neither HOME nor
+# cwd isolated, so a plain `pytest tests/` wrote llm_router MCP entries into the
+# DEVELOPER'S OWN machine config — ~/.codex/config.json, ~/.cursor/mcp.json,
+# ~/.gemini/settings.json, ~/.config/opencode/config.json and Claude Desktop's
+# config were all modified by suite runs. Nothing reported it, because nothing
+# was looking outside the repo.
+_HOME_INSTALL_TARGETS = (
+    ".codex/config.json",
+    ".cursor/mcp.json",
+    ".gemini/settings.json",
+    ".config/opencode/config.json",
+    ".claude/settings.json",
+    ".claude.json",
+    "Library/Application Support/Claude/claude_desktop_config.json",
+)
+
+# Files a LIVE process may be writing while the suite runs. ~/.claude.json is
+# Claude Code's own state file: if the suite runs from inside a Claude Code
+# session, that session rewrites it continuously. Restoring one of these would
+# revert a concurrent writer's work and destroy real state — the exact class of
+# damage this guard exists to prevent. So they are reported, never restored:
+# detection without a clobber risk.
+_REPORT_ONLY = frozenset({
+    "home:.claude.json",
+    "home:.claude/settings.json",
+})
+
 
 @pytest.fixture(autouse=True)
 def _no_repo_mutation(request):
     """Fail any test that writes an installer artifact into the real checkout."""
-    def snapshot():
-        out = {}
+    real_home = Path(os.path.expanduser("~"))
+
+    def _targets():
         for rel in _CWD_INSTALL_TARGETS:
-            p = _REPO_ROOT / rel
+            yield f"repo:{rel}", _REPO_ROOT / rel
+        for rel in _HOME_INSTALL_TARGETS:
+            yield f"home:{rel}", real_home / rel
+
+    def snapshot():
+        # (bytes, mtime_ns) — NOT bytes alone. An installer that rewrites the
+        # same JSON leaves the content identical while still having written to a
+        # file it had no business touching; on another machine, or after a code
+        # change, those same bytes would differ. Byte-equality would call that
+        # clean and let the leak persist, which is exactly what it did.
+        out = {}
+        for label, p in _targets():
             try:
-                out[rel] = p.read_bytes() if p.is_file() else None
+                out[label] = (p.read_bytes(), p.stat().st_mtime_ns) if p.is_file() else None
             except OSError:
-                out[rel] = None
+                out[label] = None
         return out
 
     before = snapshot()
@@ -897,21 +937,53 @@ def _no_repo_mutation(request):
         return
 
     # Restore first — a guard that reports damage but leaves it is half a guard.
+    # Except for _REPORT_ONLY paths, where a restore is the more dangerous act.
+    _by_label = dict(_targets())
     for rel in changed:
-        p = _REPO_ROOT / rel
+        if rel in _REPORT_ONLY:
+            continue
+        p = _by_label[rel]
         try:
             if before[rel] is None:
                 if p.is_file():
                     p.unlink()
             else:
+                _body, _mtime = before[rel]
                 p.parent.mkdir(parents=True, exist_ok=True)
-                p.write_bytes(before[rel])
+                p.write_bytes(_body)
+                os.utime(p, ns=(_mtime, _mtime))
         except OSError:  # pragma: no cover
             pass
 
     pytest.fail(
-        f"{request.node.nodeid} wrote installer artifacts into the real "
-        f"checkout: {changed}. Host installers write to Path.cwd() — use "
-        f"`monkeypatch.chdir(tmp_path)` before calling them. "
-        f"(The files have been restored.)"
+        f"{request.node.nodeid} wrote installer artifacts outside its sandbox: "
+        f"{changed}. Host installers write to Path.cwd() and Path.home() — "
+        f"isolate BOTH (`monkeypatch.chdir(tmp_path)` plus a patched home) "
+        f"before calling them. Restored: "
+        f"{sorted(set(changed) - _REPORT_ONLY)}; reported but NOT restored "
+        f"(a live process may own these): {sorted(set(changed) & _REPORT_ONLY)}."
     )
+
+
+@pytest.fixture
+def isolated_install_env(tmp_path, monkeypatch):
+    """Run real installers against a throwaway HOME and cwd.
+
+    Host installers resolve their targets with Path.home() and Path.cwd() at
+    call time, so a test that invokes one without redirecting BOTH writes to the
+    developer's actual machine. Patching pathlib.Path.home covers every module
+    regardless of how it imported Path; HOME/USERPROFILE cover anything that
+    reads the environment directly.
+    """
+    import pathlib
+
+    home = tmp_path / "home"
+    work = tmp_path / "work"
+    home.mkdir()
+    work.mkdir()
+
+    monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.chdir(work)
+    return tmp_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -840,3 +840,78 @@ def _restore_environ():
     yield
     os.environ.clear()
     os.environ.update(saved)
+
+
+# ── Repo mutation guard ───────────────────────────────────────────────────
+# FIFTH INSTANCE of the same defect class as the four above, one level out:
+# state mutated without isolation and never restored — except the state here is
+# the working tree, not a module global.
+#
+# Every host installer writes to Path.cwd(): .vscode/mcp.json, .windsurf/mcp.json,
+# .kimi/mcp.json, .github/, KIMI.md, .rules. Tests that call those installers
+# without chdir'ing first therefore write into whatever directory pytest was
+# started from — the developer's checkout. `git status` after a suite run showed
+# KIMI.md and .rules modified, every time.
+#
+# That is how the committed KIMI.md reached 53 copies of the same routing block:
+# suite runs appended to it (the idempotence guard was also broken — see
+# test_kimi_rules_idempotence.py), and the accumulated result was eventually
+# committed as if it were authored content.
+#
+# This guard keys on isolation rather than on which tests are known offenders,
+# for the same reason the env guard snapshots the whole environment: enumerating
+# offenders only holds until someone adds the next one. It RESTORES before
+# failing, so a violation cannot leave the checkout dirty even once.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_CWD_INSTALL_TARGETS = (
+    "KIMI.md",
+    ".rules",
+    ".vscode/mcp.json",
+    ".windsurf/mcp.json",
+    ".kimi/mcp.json",
+    ".cursor/rules/use-llm_router.mdc",
+    ".github/copilot-instructions.md",
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_repo_mutation(request):
+    """Fail any test that writes an installer artifact into the real checkout."""
+    def snapshot():
+        out = {}
+        for rel in _CWD_INSTALL_TARGETS:
+            p = _REPO_ROOT / rel
+            try:
+                out[rel] = p.read_bytes() if p.is_file() else None
+            except OSError:
+                out[rel] = None
+        return out
+
+    before = snapshot()
+    yield
+    after = snapshot()
+
+    changed = [rel for rel in before if before[rel] != after[rel]]
+    if not changed:
+        return
+
+    # Restore first — a guard that reports damage but leaves it is half a guard.
+    for rel in changed:
+        p = _REPO_ROOT / rel
+        try:
+            if before[rel] is None:
+                if p.is_file():
+                    p.unlink()
+            else:
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_bytes(before[rel])
+        except OSError:  # pragma: no cover
+            pass
+
+    pytest.fail(
+        f"{request.node.nodeid} wrote installer artifacts into the real "
+        f"checkout: {changed}. Host installers write to Path.cwd() — use "
+        f"`monkeypatch.chdir(tmp_path)` before calling them. "
+        f"(The files have been restored.)"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -987,3 +987,27 @@ def isolated_install_env(tmp_path, monkeypatch):
     monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.chdir(work)
     return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _redirect_claude_json(tmp_path, monkeypatch):
+    """Point install_hooks._CLAUDE_JSON_PATH at a tmp file for every test.
+
+    ~/.claude.json is Claude Code's own config, and install()/uninstall() write
+    it. Tests were patching _HOOKS_DST, _SETTINGS_PATH and _RULES_DST — the
+    paths the assertions look at — and leaving this one pointed at the real
+    file, so a suite run edited the operator's actual Claude Code config. CI
+    caught two such tests that a local run masked, because ~/.claude.json
+    already exists on a developer machine and did not exist on the runner.
+
+    Redirecting by default inverts the failure mode: a test now has to opt IN
+    to touching the real path, rather than opt out. A test that patches it
+    itself still wins — monkeypatch applies in fixture-then-test order.
+
+    Only this constant is redirected. claude_desktop_config_path() is a
+    function whose own return value is under test in test_gaps_phase1.py, so
+    it is left alone and covered by the mutation guard instead.
+    """
+    import llm_router.install_hooks as ih
+
+    monkeypatch.setattr(ih, "_CLAUDE_JSON_PATH", tmp_path / "_claude_json" / ".claude.json")

--- a/tests/install/test_statusline_preservation.py
+++ b/tests/install/test_statusline_preservation.py
@@ -40,15 +40,37 @@ def sandbox(tmp_path, monkeypatch):
     settings_path = claude / "settings.json"
     manifest_path = tmp_path / ".llm-router" / "install-manifest.json"
 
+    claude_json = tmp_path / ".claude.json"
+    desktop_config = tmp_path / "claude_desktop_config.json"
+
     monkeypatch.setattr(ih, "_HOOKS_DST", hooks_dst)
     monkeypatch.setattr(ih, "_SETTINGS_PATH", settings_path)
     monkeypatch.setattr(ih, "_RULES_DST", claude / "rules")
     monkeypatch.setattr(ih, "_CLAUDE_DIR", claude)
     monkeypatch.setattr(im, "_manifest_path", lambda: manifest_path)
+    # These two were missing, and they are surfaces install() writes to: the
+    # Claude Code CLI's ~/.claude.json and Claude Desktop's config. So this
+    # fixture — whose own docstring warns that the audit's DB tests "destroyed
+    # real user data by writing to a HOME that was not as isolated as it looked"
+    # — was doing the same thing, one file over. A suite run edited the
+    # operator's real ~/.claude.json and claude_desktop_config.json.
+    monkeypatch.setattr(ih, "_CLAUDE_JSON_PATH", claude_json)
+    monkeypatch.setattr(ih, "claude_desktop_config_path", lambda: desktop_config)
+
+    # Patching _CLAUDE_JSON_PATH is not sufficient on its own. Both
+    # _install_claude_code_cli and _uninstall_claude_code_cli prefer shelling out
+    # to the real `claude mcp add/remove --scope user`, which edits the operator's
+    # actual ~/.claude.json and ignores our patched path entirely. Hiding the
+    # binary forces the direct-JSON branch, which does respect it.
+    import shutil as _shutil
+    _real_which = _shutil.which
+    monkeypatch.setattr(
+        ih.shutil, "which", lambda n: None if n == "claude" else _real_which(n)
+    )
 
     # The safety assertion the plan requires: if any of these escaped tmp_path we
     # would be editing the operator's real config.
-    for p in (hooks_dst, settings_path, manifest_path):
+    for p in (hooks_dst, settings_path, manifest_path, claude_json, desktop_config):
         assert str(p).startswith(str(tmp_path)), f"{p} escaped the tmpdir"
 
     settings_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/qa/test_functional_hosts.py
+++ b/tests/qa/test_functional_hosts.py
@@ -91,7 +91,7 @@ def test_adapter_writes_valid_config(host: HostSpec, tmp_path: Path):
     cls = load_adapter(host)
     cfg = tmp_path / "config.json"
     adapter = cls(config_path=cfg)
-    written = adapter.install(server_command=["llm_router"])
+    written = adapter.install(server_command=["llm-router"])
 
     assert written.exists(), f"{host.id}: install did not create the config"
     data = json.loads(written.read_text())
@@ -103,11 +103,11 @@ def test_adapter_install_records_command_args(host: HostSpec, tmp_path: Path):
     cls = load_adapter(host)
     cfg = tmp_path / "config.json"
     adapter = cls(config_path=cfg)
-    adapter.install(server_command=["llm_router", "--stdio", "--verbose"])
+    adapter.install(server_command=["llm-router", "--stdio", "--verbose"])
 
     data = json.loads(cfg.read_text())
     entry = data["mcpServers"]["llm_router"]
-    assert entry["command"] == "llm_router"
+    assert entry["command"] == "llm-router"
     assert entry["args"] == ["--stdio", "--verbose"]
 
 
@@ -115,7 +115,7 @@ def test_adapter_uninstall_returns_path_when_present(host: HostSpec, tmp_path: P
     cls = load_adapter(host)
     cfg = tmp_path / "config.json"
     adapter = cls(config_path=cfg)
-    adapter.install(server_command=["llm_router"])
+    adapter.install(server_command=["llm-router"])
     result = adapter.uninstall()
     assert result is not None, f"{host.id}: uninstall should return the path it cleaned"
 
@@ -125,7 +125,7 @@ def test_adapter_is_installed_after_install(host: HostSpec, tmp_path: Path):
     cfg = tmp_path / "config.json"
     adapter = cls(config_path=cfg)
     assert not adapter.is_installed()
-    adapter.install(server_command=["llm_router"])
+    adapter.install(server_command=["llm-router"])
     assert adapter.is_installed()
 
 

--- a/tests/qa/test_multi_host_coexistence.py
+++ b/tests/qa/test_multi_host_coexistence.py
@@ -52,7 +52,7 @@ def test_cursor_install_preserves_llm_router_entry(config_with_llm_router: Path)
     from llm_router.hosts.cursor import CursorAdapter
 
     adapter = CursorAdapter(config_path=config_with_llm_router)
-    adapter.install(server_command=["llm_router"])
+    adapter.install(server_command=["llm-router"])
 
     data = json.loads(config_with_llm_router.read_text())
     assert "llm-router" in data["mcpServers"]
@@ -65,7 +65,7 @@ def test_cursor_install_preserves_llm_router_env_block(config_with_llm_router: P
     from llm_router.hosts.cursor import CursorAdapter
 
     adapter = CursorAdapter(config_path=config_with_llm_router)
-    adapter.install(server_command=["llm_router"])
+    adapter.install(server_command=["llm-router"])
 
     data = json.loads(config_with_llm_router.read_text())
     entry = data["mcpServers"]["llm-router"]
@@ -77,7 +77,7 @@ def test_cursor_uninstall_only_removes_llm_router(config_with_llm_router: Path):
     from llm_router.hosts.cursor import CursorAdapter
 
     adapter = CursorAdapter(config_path=config_with_llm_router)
-    adapter.install(server_command=["llm_router"])
+    adapter.install(server_command=["llm-router"])
     adapter.uninstall()
 
     data = json.loads(config_with_llm_router.read_text())
@@ -109,7 +109,7 @@ def test_gemini_cli_install_preserves_llm_router_entry(
     from llm_router.hosts.gemini_cli import GeminiCliAdapter
 
     adapter = GeminiCliAdapter(config_path=config_with_llm_router)
-    adapter.install(server_command=["llm_router"])
+    adapter.install(server_command=["llm-router"])
 
     data = json.loads(config_with_llm_router.read_text())
     assert "llm-router" in data["mcpServers"]
@@ -120,7 +120,7 @@ def test_gemini_cli_uninstall_only_removes_llm_router(config_with_llm_router: Pa
     from llm_router.hosts.gemini_cli import GeminiCliAdapter
 
     adapter = GeminiCliAdapter(config_path=config_with_llm_router)
-    adapter.install(server_command=["llm_router"])
+    adapter.install(server_command=["llm-router"])
     adapter.uninstall()
 
     data = json.loads(config_with_llm_router.read_text())
@@ -139,7 +139,7 @@ def test_install_llm_router_before_llm_router_still_coexist(tmp_path: Path):
 
     cfg = tmp_path / "mcp.json"
     adapter = CursorAdapter(config_path=cfg)
-    adapter.install(server_command=["llm_router"])
+    adapter.install(server_command=["llm-router"])
 
     # User manually adds llm-router
     data = json.loads(cfg.read_text())
@@ -147,7 +147,7 @@ def test_install_llm_router_before_llm_router_still_coexist(tmp_path: Path):
     cfg.write_text(json.dumps(data))
 
     # Re-install LLM Router (e.g. version upgrade)
-    adapter.install(server_command=["llm_router", "--upgraded"])
+    adapter.install(server_command=["llm-router", "--upgraded"])
 
     final = json.loads(cfg.read_text())
     assert "llm-router" in final["mcpServers"]
@@ -196,7 +196,7 @@ def test_three_way_coexistence(tmp_path: Path):
     }))
 
     adapter = CursorAdapter(config_path=cfg)
-    adapter.install(server_command=["llm_router"])
+    adapter.install(server_command=["llm-router"])
     final = json.loads(cfg.read_text())
     assert set(final["mcpServers"].keys()) == {"llm-router", "obsidian", "llm_router"}
 
@@ -287,7 +287,7 @@ def test_repeated_llm_router_installs_dont_grow_llm_router_entry(
     original_llm_router = json.loads(config_with_llm_router.read_text())["mcpServers"]["llm-router"]
 
     for _ in range(5):
-        adapter.install(server_command=["llm_router"])
+        adapter.install(server_command=["llm-router"])
 
     final_llm_router = json.loads(config_with_llm_router.read_text())["mcpServers"]["llm-router"]
     assert original_llm_router == final_llm_router, (

--- a/tests/qa/test_nonfunctional_resilience.py
+++ b/tests/qa/test_nonfunctional_resilience.py
@@ -36,7 +36,7 @@ def test_adapter_recovers_from_corrupt_json(host: HostSpec, tmp_path: Path):
     cfg.write_text("not valid json {{{{ ((( ")
     adapter = cls(config_path=cfg)
     # Install must overwrite — not raise
-    adapter.install(server_command=["llm_router"])
+    adapter.install(server_command=["llm-router"])
     data = json.loads(cfg.read_text())
     assert "llm_router" in data["mcpServers"]
 
@@ -45,7 +45,7 @@ def test_adapter_creates_missing_parent_dir(host: HostSpec, tmp_path: Path):
     cls = load_adapter(host)
     deep = tmp_path / "nested" / "deeper" / "config.json"
     adapter = cls(config_path=deep)
-    adapter.install(server_command=["llm_router"])
+    adapter.install(server_command=["llm-router"])
     assert deep.exists()
 
 
@@ -74,9 +74,9 @@ def test_adapter_handles_pre_existing_llm_router_entry(host: HostSpec, tmp_path:
         }
     }))
     adapter = cls(config_path=cfg)
-    adapter.install(server_command=["llm_router", "--new"])
+    adapter.install(server_command=["llm-router", "--new"])
     data = json.loads(cfg.read_text())
-    assert data["mcpServers"]["llm_router"]["command"] == "llm_router"
+    assert data["mcpServers"]["llm_router"]["command"] == "llm-router"
     assert data["mcpServers"]["llm_router"]["args"] == ["--new"]
 
 

--- a/tests/qa/test_performance.py
+++ b/tests/qa/test_performance.py
@@ -268,7 +268,7 @@ def test_perf_cursor_install_under_50ms(tmp_path: Path):
 
     def op():
         adapter = CursorAdapter(config_path=tmp_path / f"c_{time.perf_counter()}.json")
-        adapter.install(server_command=["llm_router"])
+        adapter.install(server_command=["llm-router"])
 
     results = measure(op, iterations=30)
     assert results["p95"] < 50.0, (
@@ -283,7 +283,7 @@ def test_perf_gemini_cli_install_under_50ms(tmp_path: Path):
         adapter = GeminiCliAdapter(
             config_path=tmp_path / f"g_{time.perf_counter()}.json"
         )
-        adapter.install(server_command=["llm_router"])
+        adapter.install(server_command=["llm-router"])
 
     results = measure(op, iterations=30)
     assert results["p95"] < 50.0, (

--- a/tests/test_cost_host.py
+++ b/tests/test_cost_host.py
@@ -207,7 +207,7 @@ class TestLlmAutoSavingsEnvelope:
 
 
 class TestInstallHost:
-    def test_install_host_codex(self, capsys):
+    def test_install_host_codex(self, capsys, isolated_install_env):
         from llm_router.cli import _install_host
         _install_host("codex")
         out = capsys.readouterr().out
@@ -215,21 +215,21 @@ class TestInstallHost:
         # --host codex writes files; check for write confirmation or skipped marker
         assert "llm_router" in out.lower() or "config" in out.lower()
 
-    def test_install_host_desktop(self, capsys):
+    def test_install_host_desktop(self, capsys, isolated_install_env):
         from llm_router.cli import _install_host
         _install_host("desktop")
         out = capsys.readouterr().out
         assert "Claude Desktop" in out
         assert "claude_desktop_config.json" in out
 
-    def test_install_host_copilot(self, capsys):
+    def test_install_host_copilot(self, capsys, isolated_install_env):
         from llm_router.cli import _install_host
         _install_host("copilot")
         out = capsys.readouterr().out
         assert "Copilot" in out
         assert "mcp.json" in out
 
-    def test_install_host_all(self, capsys):
+    def test_install_host_all(self, capsys, isolated_install_env):
         from llm_router.cli import _install_host
         _install_host("all")
         out = capsys.readouterr().out
@@ -237,7 +237,7 @@ class TestInstallHost:
         assert "Claude Desktop" in out
         assert "Copilot" in out
 
-    def test_install_host_unknown(self, capsys):
+    def test_install_host_unknown(self, capsys, isolated_install_env):
         from llm_router.cli import _install_host
         _install_host("nonexistent")
         out = capsys.readouterr().out

--- a/tests/test_gh41_doctor_validates_mcp_command.py
+++ b/tests/test_gh41_doctor_validates_mcp_command.py
@@ -1,0 +1,70 @@
+"""Regression: GH#41 root cause — `doctor` reported 0 issues on a dead server.
+
+The reporter's pipx install of 13.0.2 had `llm_router` registered in
+mcpServers with a `uv run --directory <site-packages>` command that could
+never start, and `claude mcp list` showed CONNECTION_CLOSED. `doctor` said
+everything was fine, because every MCP check asked only:
+
+    "llm_router" in settings.get("mcpServers", {})
+
+— presence of a KEY. It never read the command back and never asked whether
+that command could run. Fixing the lookup (GH#41) removes this instance; this
+check is what turns the NEXT registration bug into a doctor failure instead of
+a user bug report.
+"""
+from __future__ import annotations
+
+import llm_router.commands.doctor as doc
+
+
+def test_accepts_a_real_executable():
+    import shutil
+    real = shutil.which("sh")
+    assert not doc._mcp_command_problems({"command": real, "args": []}, "test")
+
+
+def test_accepts_a_bare_name_that_is_on_path():
+    assert not doc._mcp_command_problems({"command": "sh", "args": []}, "test")
+
+
+def test_flags_the_bare_literal_that_never_resolves():
+    """GH#41 wrote the literal string "llm_router" into Claude Desktop."""
+    problems = doc._mcp_command_problems({"command": "llm_router", "args": []}, "Claude Desktop")
+    assert problems, "a command not on PATH must be reported"
+    assert any("llm_router" in p for p in problems)
+
+
+def test_flags_uv_run_pointed_at_a_non_project_directory(tmp_path):
+    """The exact pipx failure: --directory <site-packages>, which has no pyproject.toml."""
+    import shutil
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    entry = {
+        "command": shutil.which("sh") or "sh",
+        "args": ["run", "--directory", str(site_packages), "llm-router"],
+    }
+    problems = doc._mcp_command_problems(entry, "Claude Code")
+    assert problems, "uv run against a directory with no pyproject.toml must be reported"
+    assert any("pyproject.toml" in p for p in problems)
+
+
+def test_accepts_uv_run_against_a_real_checkout(tmp_path):
+    import shutil
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    entry = {
+        "command": shutil.which("sh") or "sh",
+        "args": ["run", "--directory", str(tmp_path), "llm-router"],
+    }
+    assert not doc._mcp_command_problems(entry, "Claude Code")
+
+
+def test_flags_a_malformed_entry():
+    assert doc._mcp_command_problems({}, "test")
+    assert doc._mcp_command_problems("not-a-dict", "test")
+
+
+def test_flags_a_command_path_that_does_not_exist(tmp_path):
+    missing = tmp_path / "venvs" / "llm-routing" / "bin" / "llm-router"
+    problems = doc._mcp_command_problems({"command": str(missing), "args": []}, "Claude Desktop")
+    assert problems
+    assert any(str(missing) in p for p in problems)

--- a/tests/test_gh41_entry_point_lookup.py
+++ b/tests/test_gh41_entry_point_lookup.py
@@ -1,0 +1,103 @@
+"""Regression: GH#41 — MCP registration must find the real console script.
+
+`[project.scripts]` declares only the HYPHENATED `llm-router`; there is no
+`llm_router` console script on any install type. Every registration site used
+`shutil.which("llm_router")`, which therefore always returned None:
+
+  * install_hooks.py:723  (Claude Desktop) fell back to the literal string
+    "llm_router" — a command that can never resolve.
+  * install_hooks.py:877  (main MCP entry) fell back to
+    `uv run --directory <site-packages>` — valid only for a source checkout.
+    Against a pipx venv this is what produced CONNECTION_CLOSED.
+  * install_hooks.py:1234 (claw-code) fell back to the literal string too.
+
+Reported against a clean-slate `pipx install "llm-routing[cli]"` of 13.0.2,
+where `doctor` reported 0 issues while `claude mcp list` showed
+llm_router as CONNECTION_CLOSED.
+"""
+from __future__ import annotations
+
+import json
+
+import llm_router.install_hooks as ih
+
+
+def _pipx_which(bin_path: str):
+    """Simulate a pipx install: only the hyphenated entry point exists."""
+    def _which(name: str):
+        return bin_path if name == "llm-router" else None
+    return _which
+
+
+def test_router_bin_prefers_hyphenated_entry_point(monkeypatch):
+    monkeypatch.setattr(ih.shutil, "which", _pipx_which("/opt/pipx/venvs/llm-routing/bin/llm-router"))
+    assert ih._router_bin() == "/opt/pipx/venvs/llm-routing/bin/llm-router"
+
+
+def test_router_bin_still_finds_underscore_alias(monkeypatch):
+    """A dev checkout that exposes the legacy underscore name must still work."""
+    monkeypatch.setattr(ih.shutil, "which", lambda n: "/dev/bin/llm_router" if n == "llm_router" else None)
+    assert ih._router_bin() == "/dev/bin/llm_router"
+
+
+def test_router_bin_returns_none_when_nothing_resolves(monkeypatch):
+    monkeypatch.setattr(ih.shutil, "which", lambda n: None)
+    assert ih._router_bin() is None
+
+
+def test_mcp_entry_on_pipx_uses_binary_not_uv_run(monkeypatch):
+    """The bug: pipx install produced a `uv run --directory <site-packages>` entry."""
+    monkeypatch.setattr(ih.shutil, "which", _pipx_which("/opt/pipx/venvs/llm-routing/bin/llm-router"))
+    entry, actions = ih._build_mcp_entry()
+    assert entry is not None
+    assert entry["command"] == "/opt/pipx/venvs/llm-routing/bin/llm-router"
+    assert entry["args"] == []
+    assert "uv" not in json.dumps(entry)
+
+
+def test_mcp_entry_falls_back_to_uv_run_only_for_source_checkout(monkeypatch, tmp_path):
+    """Dev checkouts keep the uv run path — but only when a pyproject.toml is really there."""
+    pkg = tmp_path / "src" / "llm_router"
+    pkg.mkdir(parents=True)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='llm-routing'\n")
+    monkeypatch.setattr(ih, "_PACKAGE_DIR", pkg)
+    monkeypatch.setattr(ih.shutil, "which", lambda n: "/usr/bin/uv" if n == "uv" else None)
+
+    entry, actions = ih._build_mcp_entry()
+    assert entry is not None
+    assert entry["command"] == "/usr/bin/uv"
+    assert entry["args"] == ["run", "--directory", str(tmp_path), "llm-router"]
+
+
+def test_mcp_entry_warns_instead_of_writing_dead_command(monkeypatch, tmp_path):
+    """No entry point and no checkout: warn loudly, never write an unresolvable command."""
+    pkg = tmp_path / "site-packages" / "llm_router"
+    pkg.mkdir(parents=True)
+    monkeypatch.setattr(ih, "_PACKAGE_DIR", pkg)
+    monkeypatch.setattr(ih.shutil, "which", lambda n: None)
+
+    entry, actions = ih._build_mcp_entry()
+    assert entry is None
+    assert any("WARN" in a for a in actions), actions
+
+
+def test_claude_desktop_registers_resolved_binary(monkeypatch, tmp_path):
+    """GH#41: the desktop entry was the bare literal "llm_router"."""
+    cfg = tmp_path / "claude_desktop_config.json"
+    monkeypatch.setattr(ih, "claude_desktop_config_path", lambda: cfg)
+    monkeypatch.setattr(ih.shutil, "which", _pipx_which("/opt/pipx/venvs/llm-routing/bin/llm-router"))
+
+    ih._install_claude_desktop()
+    written = json.loads(cfg.read_text())["mcpServers"]["llm_router"]
+    assert written["command"] == "/opt/pipx/venvs/llm-routing/bin/llm-router"
+
+
+def test_claude_desktop_skips_when_binary_unresolvable(monkeypatch, tmp_path):
+    cfg = tmp_path / "claude_desktop_config.json"
+    monkeypatch.setattr(ih, "claude_desktop_config_path", lambda: cfg)
+    monkeypatch.setattr(ih, "_PACKAGE_DIR", tmp_path / "site-packages" / "llm_router")
+    monkeypatch.setattr(ih.shutil, "which", lambda n: None)
+
+    actions = ih._install_claude_desktop()
+    assert any("WARN" in a for a in actions), actions
+    assert not cfg.exists(), "must not write a command that cannot resolve"

--- a/tests/test_gh41_ide_configs_use_real_command.py
+++ b/tests/test_gh41_ide_configs_use_real_command.py
@@ -1,0 +1,127 @@
+"""Regression: GH#41, second front — every pull integration wrote a dead command.
+
+The Claude-side fix covered install_hooks.py's three registration sites. But
+`cli.py`, `commands/install.py` and the two IDE templates independently wrote
+`{"command": "llm_router", "args": []}` into MCP configs for VS Code, Cursor,
+Windsurf, Kimi, Gemini CLI, Copilot CLI, OpenCode, OpenClaw, Trae, Pi and
+Codex — and three such files are committed in this repo.
+
+`llm_router` is not a console script. `[project.scripts]` declares only
+`llm-router`. So every one of those configs named a command that cannot
+resolve on any install type: each pull integration was registered dead, in
+exactly the way GH#41 reported for Claude Code.
+
+These tests are the guard: no tracked config and no generated config may name
+the underscore command again.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_DEAD = '"command": "llm_router"'
+
+
+def _tracked_files() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files"], cwd=_REPO, capture_output=True, text=True, timeout=30
+    )
+    return out.stdout.splitlines()
+
+
+def test_project_scripts_really_has_no_underscore_entry_point():
+    """Guards the guard: if an `llm_router` script is ever added, these tests are moot."""
+    pyproject = (_REPO / "pyproject.toml").read_text(encoding="utf-8")
+    scripts = pyproject[pyproject.index("[project.scripts]"):]
+    scripts = scripts[: scripts.index("\n[", 1)]
+    assert "\nllm-router =" in scripts, "expected the hyphenated console script"
+    assert "\nllm_router =" not in scripts, (
+        "an underscore console script now exists — revisit these tests and GH#41"
+    )
+
+
+def test_no_tracked_file_names_the_dead_command():
+    """Shipped code and configs only. Tests legitimately name the dead command —
+    test_gh41_doctor_validates_mcp_command.py asserts that doctor FLAGS it."""
+    offenders = []
+    for rel in _tracked_files():
+        p = _REPO / rel
+        if rel.startswith("tests/") or rel.startswith("_quarantined_tests/"):
+            continue
+        if not p.is_file() or p.suffix not in {".json", ".py", ".toml", ".md", ".mdc"}:
+            continue
+        try:
+            body = p.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if _DEAD in body:
+            offenders.append(rel)
+    assert not offenders, (
+        f"these tracked files name a command that cannot resolve — "
+        f"`llm_router` is not a console script, only `llm-router` is: {sorted(offenders)}"
+    )
+
+
+@pytest.mark.parametrize("rel", [".vscode/mcp.json", ".windsurf/mcp.json", ".kimi/mcp.json"])
+def test_committed_ide_configs_name_the_real_command(rel):
+    path = _REPO / rel
+    if not path.exists():
+        pytest.skip(f"{rel} not present")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    servers = data.get("servers") or data.get("mcpServers") or {}
+    entry = servers.get("llm_router")
+    assert entry is not None, f"{rel} has no llm_router server block"
+    assert entry["command"] == "llm-router", (
+        f"{rel} must invoke the hyphenated console script, got {entry['command']!r}"
+    )
+
+
+def test_generated_ide_templates_name_the_real_command():
+    """The templates in install_hooks.py are what `install --ide` writes."""
+    import llm_router.install_hooks as ih
+
+    for name, root_key in (("_VSCODE_MCP_CONTENT", "servers"),
+                           ("_WINDSURF_MCP_CONTENT", "mcpServers")):
+        data = json.loads(getattr(ih, name))
+        entry = data[root_key]["llm_router"]
+        assert entry["command"] == "llm-router", (
+            f"{name} writes {entry['command']!r} — a command that cannot resolve"
+        )
+
+
+def test_generated_ide_templates_are_valid_json():
+    """Found while fixing the command name: both templates were INVALID JSON.
+
+    `localize()` rewrites the old tool names to the 1.0 surface — `llm_code`
+    becomes `llm(task="code")` — and these templates run that rewrite over a
+    JSON document. The replacement text contains double quotes, so it was
+    injected raw into the `"description"` string literal and broke it. The
+    templates are written to disk verbatim by install_ide_configs(), so
+    `llm-router install --ide` produced .vscode/mcp.json and
+    .windsurf/mcp.json that no IDE can parse.
+    """
+    import llm_router.install_hooks as ih
+
+    for name in ("_VSCODE_MCP_CONTENT", "_WINDSURF_MCP_CONTENT"):
+        content = getattr(ih, name)
+        try:
+            json.loads(content)
+        except json.JSONDecodeError as e:
+            raise AssertionError(f"{name} is not valid JSON: {e}") from None
+
+
+def test_installed_ide_configs_are_valid_json(tmp_path):
+    """End-to-end: what install_ide_configs actually writes must parse."""
+    import llm_router.install_hooks as ih
+
+    ih.install_ide_configs(tmp_path)
+    for rel in (".vscode/mcp.json", ".windsurf/mcp.json"):
+        written = tmp_path / rel
+        assert written.exists(), f"{rel} was not written"
+        data = json.loads(written.read_text(encoding="utf-8"))  # must not raise
+        servers = data.get("servers") or data.get("mcpServers")
+        assert servers["llm_router"]["command"] == "llm-router"

--- a/tests/test_gh42_install_uninstall_roundtrip.py
+++ b/tests/test_gh42_install_uninstall_roundtrip.py
@@ -1,0 +1,164 @@
+"""Regression: GH#42 — uninstall must be a proper inverse of install.
+
+Reported against a clean-slate pipx install of 13.0.2: after
+`llm-router uninstall`, `~/.claude/settings.json` still carried a `statusLine`
+pointing at the deleted `llm_router-statusline.sh`, and Claude Desktop still
+carried the `mcpServers.llm-router` entry.
+
+Both behaviours already had fixes that are ancestors of the v13.0.2 tag, and
+the published sdist is byte-identical to the tag for install_hooks.py — so the
+release pipeline is ruled out and the cause has to be a runtime condition.
+
+These tests state the contract directly rather than re-testing the individual
+fixes: run the real install(), run the real uninstall(), and require every
+config file to come back byte-for-byte as it started.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import llm_router.install_hooks as ih
+import llm_router.install_manifest as im
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    """Point every install surface at a throwaway HOME."""
+    claude = tmp_path / ".claude"
+    claude.mkdir()
+    monkeypatch.setattr(ih, "_CLAUDE_DIR", claude)
+    monkeypatch.setattr(ih, "_HOOKS_DST", claude / "hooks")
+    monkeypatch.setattr(ih, "_RULES_DST", claude / "rules")
+    monkeypatch.setattr(ih, "_SETTINGS_PATH", claude / "settings.json")
+    monkeypatch.setattr(ih, "_CLAUDE_JSON_PATH", tmp_path / ".claude.json")
+
+    desktop = tmp_path / "claude_desktop_config.json"
+    monkeypatch.setattr(ih, "claude_desktop_config_path", lambda: desktop)
+    monkeypatch.setattr(im, "_manifest_path", lambda: tmp_path / ".llm-router" / "install-manifest.json")
+    (tmp_path / ".llm-router").mkdir()
+
+    # No shelling out to the real `claude` CLI, and a resolvable router binary.
+    import shutil as _sh
+    real_which = _sh.which
+    monkeypatch.setattr(ih.shutil, "which", lambda n: None if n == "claude" else real_which(n))
+    return tmp_path
+
+
+def _snapshot(paths):
+    return {p: (p.read_bytes() if p.exists() else None) for p in paths}
+
+
+def test_uninstall_restores_every_config_byte_for_byte(sandbox):
+    """The contract: install then uninstall is a no-op on every config file."""
+    settings = sandbox / ".claude" / "settings.json"
+    desktop = sandbox / "claude_desktop_config.json"
+    claude_json = sandbox / ".claude.json"
+
+    # A user who already had their own status line and their own MCP server.
+    settings.write_text(json.dumps({
+        "statusLine": {"type": "command", "command": "~/bin/my-powerline.sh"},
+        "mcpServers": {"someone-elses": {"command": "other"}},
+    }, indent=2) + "\n")
+    desktop.write_text(json.dumps({"mcpServers": {"unrelated": {"command": "x"}}}, indent=2) + "\n")
+
+    before = _snapshot([settings, desktop, claude_json])
+
+    ih.install(force=True)
+    ih._install_claude_desktop()
+    ih.uninstall()
+    im.apply_uninstall()
+
+    after = _snapshot([settings, desktop, claude_json])
+    for path in before:
+        assert after[path] == before[path], (
+            f"{path.name} was not restored by uninstall.\n"
+            f"before: {before[path]!r}\nafter:  {after[path]!r}"
+        )
+
+
+def test_uninstall_removes_statusline_when_user_had_none(sandbox):
+    """Clean-slate case — the reporter's setup. No statusLine must be left behind."""
+    settings = sandbox / ".claude" / "settings.json"
+    settings.write_text(json.dumps({}, indent=2) + "\n")
+
+    ih.install(force=True)
+    assert "statusLine" in json.loads(settings.read_text()), "install did not set one — test is vacuous"
+
+    ih.uninstall()
+    im.apply_uninstall()
+    assert "statusLine" not in json.loads(settings.read_text()), (
+        "GH#42: statusLine left pointing at the deleted llm_router-statusline.sh"
+    )
+
+
+def test_uninstall_removes_claude_desktop_registration(sandbox):
+    """GH#42: install registers in claude_desktop_config.json; uninstall must undo it."""
+    desktop = sandbox / "claude_desktop_config.json"
+    desktop.write_text(json.dumps({"mcpServers": {"unrelated": {"command": "x"}}}, indent=2) + "\n")
+
+    ih._install_claude_desktop()
+    assert "llm_router" in json.loads(desktop.read_text())["mcpServers"], "test is vacuous"
+
+    ih.uninstall()
+    servers = json.loads(desktop.read_text())["mcpServers"]
+    assert "llm_router" not in servers, "GH#42: Claude Desktop registration left behind"
+    assert "unrelated" in servers, "uninstall clobbered someone else's entry"
+
+
+def test_statusline_removal_reports_failure_instead_of_swallowing_it(sandbox, monkeypatch):
+    """A silent `except OSError: pass` is how this stayed invisible."""
+    settings = sandbox / ".claude" / "settings.json"
+    settings.write_text(json.dumps({}, indent=2) + "\n")
+    ih.install(force=True)
+
+    real_unlink = ih.Path.unlink
+
+    def _boom(self, *a, **k):
+        if self.name == "llm_router-statusline.sh":
+            raise OSError("permission denied")
+        return real_unlink(self, *a, **k)
+
+    monkeypatch.setattr(ih.Path, "unlink", _boom)
+    actions = ih.uninstall()
+    assert any("statusline" in a.lower() and ("could not" in a.lower() or "warn" in a.lower())
+               for a in actions), (
+        f"a failed statusline removal must be reported, not swallowed: {actions}"
+    )
+
+
+def test_a_failed_unlink_does_not_abort_the_rest_of_uninstall(sandbox, monkeypatch):
+    """GH#42's likely root cause: one unguarded unlink aborted everything after it.
+
+    `dst.unlink()` in the hook-removal loop and `rules_dst.unlink()` were both
+    unguarded. A single OSError raised out of uninstall(), so the statusLine
+    restore and the Claude Desktop deregistration — both of which run later in
+    the function — never executed. The user sees exactly the reported symptom:
+    "uninstall left these two things behind", with no error saying why.
+    """
+    settings = sandbox / ".claude" / "settings.json"
+    desktop = sandbox / "claude_desktop_config.json"
+    settings.write_text(json.dumps({}, indent=2) + "\n")
+    ih.install(force=True)
+    ih._install_claude_desktop()
+
+    real_unlink = ih.Path.unlink
+    first_hook = ih._HOOK_DEFS[0][1]
+
+    def _boom(self, *a, **k):
+        if self.name == first_hook:
+            raise OSError("device busy")
+        return real_unlink(self, *a, **k)
+
+    monkeypatch.setattr(ih.Path, "unlink", _boom)
+    actions = ih.uninstall()  # must not raise
+
+    assert any("WARN" in a and first_hook in a for a in actions), actions
+    # The two things GH#42 reported, both of which live AFTER the failing unlink:
+    assert "statusLine" not in json.loads(settings.read_text()), (
+        "statusLine cleanup was skipped because an earlier unlink aborted uninstall"
+    )
+    assert "llm_router" not in json.loads(desktop.read_text()).get("mcpServers", {}), (
+        "Claude Desktop deregistration was skipped for the same reason"
+    )

--- a/tests/test_gh43_direct_execution_disclosure.py
+++ b/tests/test_gh43_direct_execution_disclosure.py
@@ -1,0 +1,111 @@
+"""Regression: GH#43 — the DIRECT_EXECUTION disclosure must reach PyPI users.
+
+#36 was closed by documenting `LLM_ROUTER_DIRECT_EXECUTION` in SECURITY.md.
+But pyproject's sdist `exclude` lists SECURITY.md under "Private / internal
+docs — never publish", and README.md contained zero occurrences of the name —
+it referenced the file only by a relative link that does not resolve from an
+installed package.
+
+Net effect for `pip install llm-routing`: a default-on feature that hands a
+local model write_file/edit_file/run_command unsupervised, and no shipped text
+naming it or its off switch.
+
+These tests assert the disclosure is present in a file that actually ships, so
+a future exclude-list edit fails CI rather than silently un-shipping it again.
+"""
+from __future__ import annotations
+
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_MARKER = "LLM_ROUTER_DIRECT_EXECUTION"
+_OFF_SWITCH = "LLM_ROUTER_DIRECT_EXECUTION=false"
+
+
+def test_readme_documents_direct_execution():
+    """README ships in every artifact, so the disclosure has to live there."""
+    readme = (_REPO / "README.md").read_text(encoding="utf-8")
+    assert _MARKER in readme, (
+        "README.md must name LLM_ROUTER_DIRECT_EXECUTION — SECURITY.md is "
+        "excluded from the sdist, so a relative link to it is invisible to "
+        "anyone who installed from PyPI."
+    )
+
+
+def test_readme_states_default_on_and_names_off_switch():
+    """Naming the variable is not enough — a user needs 'it is on' and 'turn it off'."""
+    readme = (_REPO / "README.md").read_text(encoding="utf-8")
+    section = readme[readme.index(_MARKER):]
+    assert _OFF_SWITCH in section, "README must give the exact off switch"
+    lowered = section[:4000].lower()
+    assert "default" in lowered and " on" in lowered, (
+        "README must state that the feature is default-ON"
+    )
+
+
+def test_readme_discloses_the_granted_tools():
+    """The material fact is unsupervised shell, not just 'a feature exists'."""
+    readme = (_REPO / "README.md").read_text(encoding="utf-8")
+    section = readme[readme.index(_MARKER):][:4000]
+    for tool in ("write_file", "edit_file", "run_command"):
+        assert tool in section, f"README must disclose that {tool} is granted"
+
+
+@pytest.fixture(scope="module")
+def built(tmp_path_factory):
+    import subprocess
+
+    out = tmp_path_factory.mktemp("dist")
+    result = subprocess.run(
+        ["uv", "build", "-o", str(out)], cwd=_REPO,
+        capture_output=True, text=True, timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"uv build unavailable or failed: {result.stderr[-400:]}")
+    wheels, sdists = list(out.glob("*.whl")), list(out.glob("*.tar.gz"))
+    if not wheels or not sdists:
+        pytest.skip("build produced no artifacts")
+    return wheels[0], sdists[0]
+
+
+@pytest.mark.slow
+def test_sdist_ships_the_disclosure(built):
+    _, sdist = built
+    with tarfile.open(sdist) as tar:
+        # README.md specifically, NOT "any shipped .md": CHANGELOG.md already
+        # mentions the variable, and a changelog line is not a disclosure —
+        # nobody reads it to learn what their install is doing right now.
+        # Top-level README only — the sdist also carries nested READMEs
+        # (e.g. _quarantined_tests/README.md) that would match a bare suffix
+        # test and make this assertion pass against the wrong file.
+        readmes = [
+            n for n in tar.getnames()
+            if n.endswith("/README.md") and n.count("/") == 1
+        ]
+        assert readmes, "sdist ships no top-level README.md"
+        body = tar.extractfile(readmes[0]).read()
+    assert _MARKER.encode() in body, (
+        f"the SDIST's README.md does not mention {_MARKER}. Either un-exclude "
+        f"the file that carries it, or mirror the section into README.md."
+    )
+    assert _OFF_SWITCH.encode() in body, "sdist README omits the off switch"
+
+
+@pytest.mark.slow
+def test_wheel_ships_the_disclosure(built):
+    """The wheel is what `pip install` actually unpacks."""
+    wheel, _ = built
+    zf = zipfile.ZipFile(wheel)
+    # The wheel carries README.md as the long_description inside METADATA.
+    meta = [n for n in zf.namelist() if n.endswith("METADATA")]
+    assert meta, "wheel has no METADATA"
+    body = zf.read(meta[0])
+    assert _MARKER.encode() in body, (
+        f"the WHEEL's METADATA (the rendered README) does not mention {_MARKER} "
+        f"— this is the text `pip show` and the PyPI project page display."
+    )
+    assert _OFF_SWITCH.encode() in body, "wheel METADATA omits the off switch"

--- a/tests/test_kimi_rules_idempotence.py
+++ b/tests/test_kimi_rules_idempotence.py
@@ -1,0 +1,68 @@
+"""Regression: _install_kimi_files appended to KIMI.md on EVERY run.
+
+The guard was `if "llm_router" not in content.lower()`, testing the existing
+file for a token the block it writes never contains: the rules text says
+"LLM Router" (with a space) throughout, and localize() rewrites the tool names
+to `llm(task="code")`. So the guard was always true and every install appended
+another copy.
+
+This is not theoretical. The committed KIMI.md in this repo carried 53 copies
+of the same section, accumulated across runs, because the installer tests
+invoke this function with the repo as cwd. The block was also never recorded
+to the install manifest, so every copy survived `llm_router uninstall`.
+"""
+from __future__ import annotations
+
+import llm_router.cli as cli
+import llm_router.install_manifest as im
+
+
+def _run_kimi(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli.Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    monkeypatch.setattr(im, "_manifest_path", lambda: tmp_path / ".llm-router" / "manifest.json")
+    return cli._install_kimi_files()
+
+
+def test_second_install_does_not_append_a_second_copy(tmp_path, monkeypatch):
+    _run_kimi(tmp_path, monkeypatch)
+    kimi = tmp_path / "KIMI.md"
+    first = kimi.read_text()
+    header_count = first.count("## LLM Router routing")
+    assert header_count == 1, f"first install wrote {header_count} copies"
+
+    _run_kimi(tmp_path, monkeypatch)
+    second = kimi.read_text()
+    assert second.count("## LLM Router routing") == 1, (
+        f"second install appended again — {second.count('## LLM Router routing')} copies now"
+    )
+    assert second == first, "KIMI.md changed on a repeat install"
+
+
+def test_ten_installs_still_leave_one_copy(tmp_path, monkeypatch):
+    """The committed file reached 53 copies; one run per suite execution."""
+    for _ in range(10):
+        _run_kimi(tmp_path, monkeypatch)
+    body = (tmp_path / "KIMI.md").read_text()
+    assert body.count("## LLM Router routing") == 1, (
+        f"{body.count('## LLM Router routing')} copies after 10 installs"
+    )
+
+
+def test_user_content_is_preserved(tmp_path, monkeypatch):
+    kimi = tmp_path / "KIMI.md"
+    kimi.write_text("# My Project\n\nMy own notes.\n")
+    _run_kimi(tmp_path, monkeypatch)
+    body = kimi.read_text()
+    assert "My own notes." in body, "installer clobbered the user's file"
+    assert "## LLM Router routing" in body, "installer did not append its block"
+
+
+def test_appended_block_is_recorded_for_uninstall(tmp_path, monkeypatch):
+    """It recorded nothing, so uninstall could not strip what it wrote."""
+    kimi = tmp_path / "KIMI.md"
+    kimi.write_text("# My Project\n")
+    _run_kimi(tmp_path, monkeypatch)
+    assert (
+        im.find("text_block", kimi) is not None or im.find("created_file", kimi) is not None
+    ), "KIMI.md edit was never recorded to the install manifest"

--- a/tests/test_p0_6_install_packaging.py
+++ b/tests/test_p0_6_install_packaging.py
@@ -77,5 +77,5 @@ def test_host_snippets_invoke_canonical_command() -> None:
     # (the stdio entry), never `uvx <pkg>`.
     for host, snippet in install._HOST_SNIPPETS.items():
         if "command" in snippet:
-            assert ("command: llm_router" in snippet) or ('"command": "llm_router"' in snippet), host
+            assert ("command: llm-router" in snippet) or ('"command": "llm-router"' in snippet), host
             assert "uvx" not in snippet, f"{host} still uses uvx"

--- a/tests/test_p0_6_install_packaging.py
+++ b/tests/test_p0_6_install_packaging.py
@@ -58,7 +58,10 @@ def test_claude_code_host_routes_to_default_install_not_unknown(monkeypatch) -> 
     assert install_host_calls == []  # did NOT go down the snippet path
 
 
-def test_all_snippet_hosts_resolve() -> None:
+def test_all_snippet_hosts_resolve(isolated_install_env) -> None:
+    # Runs the REAL installer for every snippet host. Without isolation that
+    # wrote MCP entries into the developer's own ~/.codex, ~/.cursor, ~/.gemini
+    # and opencode config on every suite run.
     for host in install._HOST_SNIPPETS:
         out = _run_host(["--host", host])
         assert "Unknown host" not in out, host

--- a/tests/test_red2_8_01_uninstall_host_integrations.py
+++ b/tests/test_red2_8_01_uninstall_host_integrations.py
@@ -15,11 +15,11 @@ def test_removes_llm_router_from_all_json_hosts(tmp_path, monkeypatch):
 
     gem = tmp_path / ".gemini" / "settings.json"
     gem.parent.mkdir(parents=True)
-    gem.write_text(json.dumps({"mcpServers": {"llm_router": {"command": "llm_router"}, "keep": {"x": 1}}}))
+    gem.write_text(json.dumps({"mcpServers": {"llm_router": {"command": "llm-router"}, "keep": {"x": 1}}}))
     (tmp_path / ".gemini" / "extensions" / "llm_router").mkdir(parents=True)
     cur = tmp_path / ".cursor" / "mcp.json"
     cur.parent.mkdir(parents=True)
-    cur.write_text(json.dumps({"mcpServers": {"llm_router": {"command": "llm_router"}}}))
+    cur.write_text(json.dumps({"mcpServers": {"llm_router": {"command": "llm-router"}}}))
     codex = tmp_path / ".codex" / "config.toml"
     codex.parent.mkdir(parents=True)
     codex.write_text('[model_providers.llm_router]\nname = "LLM Router"\nbase_url = "x"\n\n[other]\nk = 1\n')

--- a/tests/test_sdist_excludes_quarantined_tests.py
+++ b/tests/test_sdist_excludes_quarantined_tests.py
@@ -1,0 +1,69 @@
+"""Regression: the sdist shipped _quarantined_tests/ to PyPI.
+
+pyproject's sdist exclude list anchors "/tests/", but the quarantine lives at
+the repo ROOT as _quarantined_tests/ and was never added. 13.0.2 shipped 16
+files of dead, uncollectable test code — modules that could not even be
+imported after the 13.0.0 sync, which is why they were quarantined.
+
+Nobody installing llm-routing needs them, and shipping tests that fail to
+import invites exactly the wrong conclusion about the package.
+"""
+from __future__ import annotations
+
+import subprocess
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+
+
+def test_the_quarantine_still_exists_at_the_root():
+    """Guards the guard: if the directory is ever deleted, this test is vacuous."""
+    if not (_REPO / "_quarantined_tests").is_dir():
+        pytest.skip("quarantine already removed from the tree")
+
+
+@pytest.fixture(scope="module")
+def built(tmp_path_factory):
+    out = tmp_path_factory.mktemp("dist")
+    result = subprocess.run(
+        ["uv", "build", "-o", str(out)], cwd=_REPO,
+        capture_output=True, text=True, timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"uv build unavailable or failed: {result.stderr[-400:]}")
+    wheels, sdists = list(out.glob("*.whl")), list(out.glob("*.tar.gz"))
+    if not wheels or not sdists:
+        pytest.skip("build produced no artifacts")
+    return wheels[0], sdists[0]
+
+
+@pytest.mark.slow
+def test_sdist_does_not_ship_quarantined_tests(built):
+    _, sdist = built
+    with tarfile.open(sdist) as tar:
+        leaked = [n for n in tar.getnames() if "_quarantined_tests" in n]
+    assert not leaked, (
+        f"the SDIST ships {len(leaked)} quarantined test files. pyproject's "
+        f"exclude list anchors '/tests/' but never covered this directory: {leaked[:5]}"
+    )
+
+
+@pytest.mark.slow
+def test_wheel_does_not_ship_quarantined_tests(built):
+    """`uv build` builds the wheel FROM the sdist, so both must be checked."""
+    wheel, _ = built
+    leaked = [n for n in zipfile.ZipFile(wheel).namelist() if "_quarantined_tests" in n]
+    assert not leaked, f"the WHEEL ships quarantined test files: {leaked[:5]}"
+
+
+@pytest.mark.slow
+def test_sdist_does_not_ship_the_active_test_suite(built):
+    """The sibling assertion — '/tests/' is excluded, so prove it stays excluded."""
+    _, sdist = built
+    with tarfile.open(sdist) as tar:
+        leaked = [n for n in tar.getnames() if "/tests/" in n]
+    assert not leaked, f"the SDIST ships the active test suite: {leaked[:5]}"

--- a/tests/test_settings_backup_is_pre_install.py
+++ b/tests/test_settings_backup_is_pre_install.py
@@ -1,0 +1,90 @@
+"""Regression: settings.json.bak held POST-install state.
+
+`_backup_before_overwrite(_SETTINGS_PATH)` was called from the statusLine
+branch, which runs late in install() — after the hook registrations and the
+mcpServers entry have already been written and saved. The resulting
+`settings.json.bak` therefore contained llm_router's own hooks and MCP server,
+with only the statusLine still at its original value.
+
+A file named `settings.json.bak` promises the settings as they were. A user who
+reaches for it after a bad install and copies it back would silently reinstate
+every llm_router hook. The backup has to be taken before the first mutation to
+mean what its name says.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import llm_router.install_hooks as ih
+import llm_router.install_manifest as im
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    claude = tmp_path / ".claude"
+    claude.mkdir()
+    monkeypatch.setattr(ih, "_CLAUDE_DIR", claude)
+    monkeypatch.setattr(ih, "_HOOKS_DST", claude / "hooks")
+    monkeypatch.setattr(ih, "_RULES_DST", claude / "rules")
+    monkeypatch.setattr(ih, "_SETTINGS_PATH", claude / "settings.json")
+    monkeypatch.setattr(ih, "_CLAUDE_JSON_PATH", tmp_path / ".claude.json")
+    monkeypatch.setattr(ih, "claude_desktop_config_path", lambda: tmp_path / "desktop.json")
+    monkeypatch.setattr(im, "_manifest_path", lambda: tmp_path / ".llm-router" / "m.json")
+    (tmp_path / ".llm-router").mkdir()
+    import shutil as _sh
+    real_which = _sh.which
+    monkeypatch.setattr(ih.shutil, "which", lambda n: None if n == "claude" else real_which(n))
+    return tmp_path
+
+
+def _original_settings() -> dict:
+    return {
+        "statusLine": {"type": "command", "command": "~/bin/my-powerline.sh"},
+        "mcpServers": {"someone-elses": {"command": "other"}},
+    }
+
+
+def test_backup_is_a_true_pre_install_snapshot(sandbox):
+    settings = sandbox / ".claude" / "settings.json"
+    original = _original_settings()
+    settings.write_text(json.dumps(original, indent=2) + "\n")
+
+    ih.install(force=True)
+
+    bak = sandbox / ".claude" / "settings.json.bak"
+    assert bak.exists(), "install replaced settings.json but wrote no backup"
+    restored = json.loads(bak.read_text())
+    assert restored == original, (
+        "settings.json.bak is not the pre-install state.\n"
+        f"expected: {original}\ngot:      {restored}"
+    )
+
+
+def test_backup_contains_none_of_llm_routers_own_writes(sandbox):
+    """The concrete failure: restoring the .bak reinstated llm_router's hooks."""
+    settings = sandbox / ".claude" / "settings.json"
+    settings.write_text(json.dumps(_original_settings(), indent=2) + "\n")
+
+    ih.install(force=True)
+
+    bak = json.loads((sandbox / ".claude" / "settings.json.bak").read_text())
+    assert "hooks" not in bak, "backup carries llm_router's hook registrations"
+    assert "llm_router" not in bak.get("mcpServers", {}), (
+        "backup carries llm_router's MCP server entry"
+    )
+    assert bak["mcpServers"] == {"someone-elses": {"command": "other"}}
+
+
+def test_restoring_the_backup_undoes_the_install(sandbox):
+    """The property a user actually relies on."""
+    settings = sandbox / ".claude" / "settings.json"
+    original_bytes = (json.dumps(_original_settings(), indent=2) + "\n").encode()
+    settings.write_bytes(original_bytes)
+
+    ih.install(force=True)
+    bak = sandbox / ".claude" / "settings.json.bak"
+    settings.write_bytes(bak.read_bytes())
+
+    assert json.loads(settings.read_text()) == _original_settings()

--- a/tests/test_vscode_cursor_install.py
+++ b/tests/test_vscode_cursor_install.py
@@ -54,7 +54,7 @@ class TestInstallVsCodeFiles:
         assert "llm_router" in data["servers"]
         # P0-6: canonical stdio entry is `llm_router` (the console script), not the
         # deprecated `uvx claude-code-llm_router` package.
-        assert data["servers"]["llm_router"]["command"] == "llm_router"
+        assert data["servers"]["llm_router"]["command"] == "llm-router"
         assert data["servers"]["llm_router"]["args"] == []
 
     def test_action_confirms_file_written(self, fake_home):

--- a/tests/test_vscode_cursor_install.py
+++ b/tests/test_vscode_cursor_install.py
@@ -13,8 +13,16 @@ import pytest
 
 
 @pytest.fixture
-def fake_home(tmp_path, monkeypatch):
-    """Redirect Path.home() and os.environ to a temp directory."""
+def fake_home(tmp_path, monkeypatch, fake_cwd):
+    """Redirect Path.home(), os.environ AND the working directory to a temp dir.
+
+    fake_cwd was a separate opt-in fixture, and most tests here took only
+    fake_home. But the VS Code and Windsurf installers write their WORKSPACE
+    config relative to Path.cwd() — .vscode/mcp.json, .github/ — so a redirected
+    home alone still let them write into whatever directory pytest ran from.
+    Depending on fake_cwd makes the isolation total by default; tests that
+    already request both get the same tmp_path and are unaffected.
+    """
     monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
     if sys.platform == "win32":

--- a/uv.lock
+++ b/uv.lock
@@ -1197,7 +1197,7 @@ wheels = [
 
 [[package]]
 name = "llm-routing"
-version = "13.0.2"
+version = "13.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Fixes #41 and #43, and four defects found while reproducing #42.

## #41 — every MCP registration named a command that does not exist

`[project.scripts]` declares only the hyphenated `llm-router`, so `shutil.which("llm_router")` returned `None` on **every** install type — pipx, pip and uv alike. **Thirty call sites** depended on it:

- `install_hooks.py` (3) — Claude Desktop and claw-code fell back to the literal string `"llm_router"`; the main registration fell back to `uv run --directory <site-packages>`, which is exactly the `CONNECTION_CLOSED` reported against a clean pipx install of 13.0.2.
- `cli.py` (17) and `commands/install.py` (11) — every pull integration (VS Code, Cursor, Windsurf, Kimi, Gemini CLI, Copilot CLI, OpenCode, OpenClaw, Trae, Pi, Codex) was registered dead the same way.
- Three configs committed in this repo (`.vscode`, `.windsurf`, `.kimi`) shipped the dead command to anyone cloning it.

Fixed with `_router_bin()` (hyphen first, underscore second for dev checkouts) and `_build_mcp_entry()`. The `uv run` fallback is now gated on the directory actually containing a `pyproject.toml`, and an unresolvable binary **skips** registration with a warning rather than writing a command that cannot run — a missing server is diagnosable, a dead one is not.

**Root cause: `doctor` reported 0 issues while the server was dead.** Every MCP check asked only whether the key `llm_router` was present in `mcpServers`; none read the command back. It now verifies the command exists, is executable, and — for `uv run --directory DIR` — that `DIR` is a real project root. This turns the whole class into a doctor failure instead of a user bug report.

**Found while fixing it:** both IDE config templates were **invalid JSON**. `localize()` rewrites tool names to the 1.0 surface (`llm_code` → `llm(task="code")`) and was running that substitution over a raw JSON document, injecting unescaped quotes into the `"description"` string literal. The templates are written verbatim, so `install --ide` produced `.vscode/mcp.json` and `.windsurf/mcp.json` that no IDE could parse. Both are now built with `json.dumps`.

## #43 — the DIRECT_EXECUTION disclosure never reached PyPI users

#36 was closed by documenting `LLM_ROUTER_DIRECT_EXECUTION` in `SECURITY.md`, which the sdist excludes, and `README.md` referenced it only by a relative link that does not resolve from an installed package. So `pip install llm-routing` shipped a default-on feature granting a local model `write_file`/`edit_file`/`run_command` unsupervised, with no shipped text naming it or its off switch.

The section is now mirrored into `README.md` (default-on status, the three granted tools, what the blocklist misses, the exact off switch), the `SECURITY.md` link is absolute, and a test asserts the disclosure survives into the built sdist and wheel.

## #42 — could not be reproduced as written; four real defects found instead

Both reported behaviours already had fixes that are ancestors of the `v13.0.2` tag, and the published sdist is **byte-identical to the tag** for `install_hooks.py` — release pipeline ruled out. Asserting the real contract (install then uninstall is a no-op on every config file) surfaced four genuine defects:

1. **An unguarded `unlink()` aborted uninstall partway through.** One `OSError` in the hook-removal loop or on the rules file raised straight out of `uninstall()`, so the statusLine restore and Claude Desktop deregistration — both later in the function — silently never ran. This produces exactly the reported symptom, on exactly the two reported surfaces, with no error explaining why. Most likely root cause of #42.
2. An empty `hooks` scaffold left behind for users who had none before install.
3. `~/.claude.json` left as a `{"mcpServers": {}}` husk — now recorded as `created_file` and removed only when install is the sole reason it exists.
4. `settings.json.bak` held **post**-install state, so restoring it reinstated the very hooks a user was trying to remove. The snapshot is now taken before the first mutation.

The silent `except OSError: pass` around statusLine removal now reports.

## Packaging and test hygiene

- **`_quarantined_tests/` no longer ships to PyPI.** The exclude list anchored `/tests/`; the quarantine lives at the repo root, so 13.0.2 shipped 16 files of dead, uncollectable test code.
- **`KIMI.md` gained a duplicate routing block on every install.** The guard tested for `llm_router`, a token the block it writes never contains — the committed file had reached 53 copies.
- **The test suite wrote to the developer's repo *and machine config*.** Nine tests across four files invoked real installers without isolating `Path.home()` and `Path.cwd()`, so `pytest tests/` modified `~/.codex`, `~/.cursor`, `~/.gemini`, `~/.config/opencode`, `~/.claude.json` and Claude Desktop's config. A new autouse guard snapshots those surfaces, restores them, and fails the offending test by nodeid; live-state files are reported but never restored, so the guard cannot clobber a concurrent writer.

## Verification

- **36 new tests**, each proven to fail against the unpatched code first (#42's against the pristine `v13.0.2` `install_hooks.py`).
- Full suite reports **zero guard violations** and leaves the checkout untouched after a complete run.
- `ruff` clean; identity, version-sync and plugin-sync gates all pass.
- **End-to-end against a real wheel in an isolated HOME:** the installed venv exposes only `llm-router`, both surfaces register the real binary path, the MCP server completes an `initialize` handshake (directly refuting `CONNECTION_CLOSED`), `doctor` flags the corrupted 13.0.2 shape with a precise diagnosis, install→uninstall restores `settings.json` and `claude_desktop_config.json` semantically identical with a pre-existing `~/.claude.json` preserved, and five consecutive kimi installs leave one copy of the block with user content intact.

The four remaining suite failures (`test_t3_s2_max_wall_clock_seconds`, `test_t4_m2_classification_allowlist`) pre-date this branch and are local-environment only — they need a configured provider and CI is green on them at the branch point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pPYEnwsfgXjgEybvTGHZW