### PR TITLE
Fix the flaky tests (#75) — two unrelated bugs, one of them in production code

### DIFF
--- a/src/llm_router/judge.py
+++ b/src/llm_router/judge.py
@@ -17,6 +17,21 @@ from datetime import datetime, timedelta
 from llm_router.cost import _get_db
 from llm_router.providers import call_llm
 
+# GH#75: fire-and-forget tasks created below outlive the test that spawned
+# them. pytest-asyncio's `asyncio_default_fixture_loop_scope = "session"`
+# means every test shares ONE event loop, so a judge task created by test A
+# (via `asyncio.create_task`, never awaited) can still be pending when test B
+# starts. Since `call_llm` -> `litellm.acompletion` is patched globally by
+# whichever test currently holds a `with patch("litellm.acompletion", ...)`
+# block, test A's orphaned judge call gets dispatched through test B's mock
+# and silently overwrites test B's captured request kwargs with
+# `model="claude-haiku-4-5-20251001"` — the exact "wrong provider" flake
+# reported in GH#75 (test_integration.py comparing captured["model"] against
+# the test's own override). Tracking every scheduled task here lets a test
+# fixture (`drain_pending_judge_tasks`) await/cancel them before the next
+# test runs, instead of letting them survive into it.
+_pending_tasks: set[asyncio.Task] = set()
+
 
 async def evaluate_response_async(
     prompt: str,
@@ -42,7 +57,32 @@ async def evaluate_response_async(
         return
 
     # Fire background task without awaiting
-    asyncio.create_task(_evaluate_background(prompt, response, task_type, routing_decision_id))
+    task = asyncio.create_task(_evaluate_background(prompt, response, task_type, routing_decision_id))
+    # Track real Task/Future objects only — tests that patch
+    # `asyncio.create_task` itself get a MagicMock back, which is neither
+    # awaitable by `asyncio.wait` nor a real leak risk.
+    if isinstance(task, asyncio.Future):
+        _pending_tasks.add(task)
+        task.add_done_callback(_pending_tasks.discard)
+
+
+async def drain_pending_judge_tasks(timeout: float = 2.0) -> None:
+    """Test-only helper: await (or cancel) every in-flight judge task.
+
+    GH#75: without this, a judge task scheduled by one test can execute
+    during a LATER test's `await`s, on the session-wide event loop, and hit
+    whatever mock that later test currently has installed. Call this from an
+    autouse fixture after each test so no task ever crosses a test boundary.
+    """
+    if not _pending_tasks:
+        return
+    pending = list(_pending_tasks)
+    _done, still_pending = await asyncio.wait(pending, timeout=timeout)
+    for t in still_pending:
+        t.cancel()
+    if still_pending:
+        await asyncio.gather(*still_pending, return_exceptions=True)
+    _pending_tasks.difference_update(pending)
 
 
 async def _evaluate_background(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -601,6 +601,29 @@ def _reset_quality_store():
 
 
 @pytest.fixture(autouse=True)
+async def _drain_judge_background_tasks():
+    """Await/cancel every fire-and-forget judge task before the next test runs.
+
+    GH#75: ``llm_router.judge.evaluate_response_async`` schedules
+    ``_evaluate_background`` via ``asyncio.create_task`` and never awaits it.
+    Because ``asyncio_default_fixture_loop_scope = "session"`` (see
+    pyproject.toml) gives the whole suite ONE event loop, a task created by
+    one test can still be pending — and gets scheduled to run — during a
+    LATER test's own ``await`` points. That later test's
+    ``patch("litellm.acompletion", ...)`` is a global attribute patch, so the
+    orphaned task's ``call_llm(model="claude-haiku-4-5-20251001", ...)`` call
+    is dispatched through the later test's mock and silently overwrites its
+    captured request kwargs — the "expected provider X, got
+    claude-haiku-4-5-20251001" flake in tests/test_integration.py. Draining
+    here (after every test, in addition to whatever `mock_env`/`temp_db`
+    reset) guarantees no judge task ever survives to poison another test.
+    """
+    yield
+    from llm_router.judge import drain_pending_judge_tasks
+    await drain_pending_judge_tasks()
+
+
+@pytest.fixture(autouse=True)
 def _hermetic_host_state(monkeypatch):
     """Isolate router tests from real host state (repo config + CLI probes).
 
@@ -636,6 +659,22 @@ def _hermetic_host_state(monkeypatch):
     # re-enables per-test (test-level monkeypatch wins). OKF stays ON — it is
     # part of the shipped default and its suites exercise it with a tmp base.
     monkeypatch.setenv("LLM_ROUTER_ENSEMBLE", "off")
+    # GH#75: judge.evaluate_response_async samples LLM_ROUTER_JUDGE_SAMPLE_RATE
+    # (default 0.1 in production) and, on a hit, fires an unawaited
+    # asyncio.create_task that calls litellm.acompletion(model="claude-haiku-
+    # 4-5-20251001", ...) via call_llm. Any test that patches
+    # "litellm.acompletion" is a global attribute patch, so if that background
+    # task happens to run before the test's own assertion — a real race, since
+    # the task is scheduled, not awaited — it silently overwrites the test's
+    # captured request kwargs with the judge's model. That's the exact
+    # "expected provider X, got claude-haiku-4-5-20251001" flake in
+    # tests/test_integration.py, and it fired ~10% of the time (whenever
+    # random.random() happened to clear the default sample rate) independent
+    # of test order. Default sampling OFF here so ordinary tests never race
+    # this task at all; tests/test_judge.py explicitly re-enables it per test
+    # (test-level monkeypatch wins over this autouse default), and
+    # `_drain_judge_background_tasks` below still cleans up after those.
+    monkeypatch.setenv("LLM_ROUTER_JUDGE_SAMPLE_RATE", "0")
     yield
 
 

--- a/tests/test_gh55_routing_decision_stores.py
+++ b/tests/test_gh55_routing_decision_stores.py
@@ -32,6 +32,26 @@ from llm_router.commands import doctor
 
 
 def _db(path, *, table=True, rows=0, other_rows=0):
+    """Build a scratch usage DB matching production's actual timestamp convention.
+
+    GH#75: this previously stored ``datetime('now','localtime')`` — i.e. an
+    already-local wall-clock string. `_routing_decision_state`'s read query
+    (matching the real schema in cost.py, where both tables default
+    ``timestamp`` to ``datetime('now')`` = UTC) applies the ``'localtime'``
+    modifier ONCE at read time, correctly converting a UTC timestamp to local
+    time. Applying ``'localtime'`` a SECOND time on top of a value that was
+    already shifted double-shifts it by the host's UTC offset. For any
+    nonzero-offset timezone that flips the row onto the "wrong" side of local
+    midnight for `offset` hours out of every day (23:00-24:00 local for a
+    positive offset, 00:00-`offset` for a negative one) — during which the
+    row's computed date no longer equals `date('now','localtime')`, and it
+    silently drops out of "today"'s count. That is what made this test flaky
+    by wall-clock time of day (misdiagnosed as order-dependent test pollution
+    since "alone" vs. "in the full suite" simply run at different real
+    times). Storing UTC here, like production does, makes the single
+    'localtime' conversion in the reader correct regardless of host TZ or
+    time of day.
+    """
     conn = sqlite3.connect(str(path))
     if table:
         conn.execute(
@@ -40,11 +60,11 @@ def _db(path, *, table=True, rows=0, other_rows=0):
         )
         for _ in range(rows):
             conn.execute(
-                "INSERT INTO routing_decisions VALUES (datetime('now','localtime'),'simple','')"
+                "INSERT INTO routing_decisions VALUES (datetime('now'),'simple','')"
             )
     conn.execute("CREATE TABLE usage (timestamp TEXT, model TEXT)")
     for _ in range(other_rows):
-        conn.execute("INSERT INTO usage VALUES (datetime('now','localtime'),'ollama/x')")
+        conn.execute("INSERT INTO usage VALUES (datetime('now'),'ollama/x')")
     conn.commit()
     conn.close()
     return path


### PR DESCRIPTION
Closes #75

The issue framed both symptom groups as "order-dependent shared state." That was half right. They are two independent bugs, and the second one has nothing to do with test ordering at all.

## Group A — `test_integration.py`, and a real production hazard

`judge.evaluate_response_async` did `asyncio.create_task(...)` and never awaited it or kept a reference to it.

`pyproject.toml` sets `asyncio_default_fixture_loop_scope = "session"`, so the entire suite shares **one** event loop. An orphaned judge task spawned by one test can therefore execute during a *later* test's `await`s. `_evaluate_background` calls `call_llm(model="claude-haiku-4-5-20251001", ...)` → `litellm.acompletion` — a global attribute that whichever test is currently running has patched with `with patch("litellm.acompletion", ...)`. The stray call gets dispatched through **that** test's mock and overwrites its `captured` dict.

Which is precisely the reported failure: `assert 'claude-haiku-4-5-20251001' == 'perplexity/sonar'`. The Claude model in the assertion was never a routing decision — it is the judge's own hardcoded model bleeding across a test boundary.

**This also explains the part of the issue that looked impossible.** I had proven the same SHA passed and failed with only a workflow YAML file differing, and concluded "flake" without a mechanism. The mechanism is that the production sample rate is `0.1`, so it fires on `random.random()` — not on ordering. Identical code genuinely can go either way.

The fix tracks tasks in a module-level set and adds `drain_pending_judge_tasks()`, mirroring the existing `reset_quality_store()` / `reset_dynamic_routing()` helpers, drained by a new autouse fixture.

**Holding a strong reference is a production fix, not just test scaffolding**: asyncio may garbage-collect a pending task that nothing refers to, so judge evaluations could previously vanish mid-flight with no trace.

## Group B — a timezone bug in the test's own SQL

Not shared state at all.

Production stores `timestamp TEXT DEFAULT (datetime('now'))` — UTC — and `doctor._routing_decision_state` correctly applies `'localtime'` **once** when comparing against today. But the test helper inserted rows with `datetime('now','localtime')`, already local, so the reader's conversion shifted them a **second** time.

In any nonzero-offset timezone, rows written during the `|offset|`-hour window straddling local midnight land on the wrong day and fall out of "today" — giving the reported `0 == 4` and `0 == 7`. It merely *looked* order-dependent because running a file alone versus inside the full suite happens at a different wall-clock moment.

The helper now stores UTC, matching production's convention.

## Verification

Both repros are deterministic rather than probabilistic, which is the point:

```
LLM_ROUTER_JUDGE_SAMPLE_RATE=1 pytest tests/test_integration.py
TZ=Etc/GMT-14 pytest tests/test_gh55_routing_decision_stores.py
```

- Post-fix: 3 passed and 6 passed.
- Mutation check (independently re-run): reverting the fix gives `3 failed` and `2 failed`; restoring clears both.
- Full suite run twice, once under the adversarial combination `TZ=Etc/GMT-14` + `LLM_ROUTER_JUDGE_SAMPLE_RATE=1` — a strictly harder condition than any random seed. Both runs show zero #75-family failures.

## Out of scope

The remaining failures are the #74 family (`No providers available ... Configured providers: {'xai'}`), which fail identically alone, in-suite, and with a clean `HOME`. One of them, `test_t4_m2_classification_allowlist.py::test_strict_with_all_providers_forbidden_raises_permission_denied`, was surfaced by #76's edits to that file and is confirmed pre-existing on current `main`. Tracked in #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112d4uPHtwLAoThVHZxKtwE