### PR TITLE
Stop install and doctor printing a command that does not exist (#72)

### DIFF
--- a/src/llm_router/commands/doctor.py
+++ b/src/llm_router/commands/doctor.py
@@ -124,7 +124,7 @@ def _run_doctor_host(host: str) -> None:
                     print(
                         _fail(
                             f"{dst_name}  — not installed",
-                            fix="llm_router install",
+                            fix="llm-router install",
                         )
                     )
                     issues.append(f"Hook {dst_name} missing")
@@ -163,7 +163,7 @@ def _run_doctor_host(host: str) -> None:
                         print(
                             _fail(
                                 f"llm_router not in servers ({mcp_json})",
-                                fix="llm_router install --host vscode",
+                                fix="llm-router install --host vscode",
                             )
                         )
                         issues.append("llm_router not registered in VS Code mcp.json")
@@ -173,7 +173,7 @@ def _run_doctor_host(host: str) -> None:
                 print(
                     _fail(
                         f"mcp.json not found at {mcp_json}",
-                        fix="llm_router install --host vscode",
+                        fix="llm-router install --host vscode",
                     )
                 )
                 issues.append("VS Code mcp.json missing")
@@ -200,7 +200,7 @@ def _run_doctor_host(host: str) -> None:
                         print(
                             _fail(
                                 f"llm_router not in mcpServers ({mcp_json})",
-                                fix="llm_router install --host cursor",
+                                fix="llm-router install --host cursor",
                             )
                         )
                         issues.append("llm_router not registered in Cursor mcp.json")
@@ -210,7 +210,7 @@ def _run_doctor_host(host: str) -> None:
                 print(
                     _fail(
                         f"mcp.json not found at {mcp_json}",
-                        fix="llm_router install --host cursor",
+                        fix="llm-router install --host cursor",
                     )
                 )
                 issues.append("Cursor mcp.json missing")
@@ -241,7 +241,7 @@ def _run_doctor_host(host: str) -> None:
                         print(_fail(
                             "Codex model_provider is force-set to 'llm_router' — "
                             "this breaks Codex CLI (gateway wire-format mismatch)",
-                            fix="llm_router install --host codex --mode gateway",
+                            fix="llm-router install --host codex --mode gateway",
                         ))
                         issues.append("Codex model_provider forced to llm_router (breaks Codex)")
                     else:
@@ -255,7 +255,7 @@ def _run_doctor_host(host: str) -> None:
                     else:
                         print(_fail(
                             "LLM Router model provider table missing",
-                            fix="llm_router install --host codex --mode gateway",
+                            fix="llm-router install --host codex --mode gateway",
                         ))
                         issues.append("Codex LLM Router provider table missing")
                 except OSError as e:
@@ -264,7 +264,7 @@ def _run_doctor_host(host: str) -> None:
             else:
                 print(_fail(
                     f"config.toml not found at {config_toml}",
-                    fix="llm_router install --host codex --mode gateway",
+                    fix="llm-router install --host codex --mode gateway",
                 ))
                 issues.append("Codex config.toml missing")
 
@@ -754,7 +754,7 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
 
     issues: list[str] = []
 
-    print(f"\n{_bold('llm_router doctor')}\n")
+    print(f"\n{_bold('llm-router doctor')}\n")
 
     # ── 1. Hooks ───────────────────────────────────────────────────────────
     print(_bold("  Hooks"))
@@ -774,7 +774,7 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
                         )
                     )
                     issues.append(
-                        f"Hook {dst_name} is outdated — run `llm_router install --force`"
+                        f"Hook {dst_name} is outdated — run `llm-router install --force`"
                     )
                 else:
                     print(_ok(f"{dst_name}  ({event})"))
@@ -784,7 +784,7 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
             print(
                 _fail(
                     f"{dst_name}  ({event})  — not installed",
-                    fix="llm_router install",
+                    fix="llm-router install",
                 )
             )
             issues.append(f"Hook {dst_name} not installed")
@@ -813,12 +813,12 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
                                 print(
                                     _fail(
                                         f"{os.path.basename(_parts[-1])} → {_interp} NOT FOUND",
-                                        fix="llm_router install --force",
+                                        fix="llm-router install --force",
                                     )
                                 )
                                 issues.append(
                                     f"Hook interpreter missing: {_interp} — "
-                                    f"run `llm_router install --force` to fix"
+                                    f"run `llm-router install --force` to fix"
                                 )
         except Exception as _e:
             print(_warn(f"Could not parse settings.json: {_e}"))
@@ -857,7 +857,7 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
     if rules_dst.exists():
         print(_ok("llm_router.md"))
     else:
-        print(_fail("llm_router.md — not installed", fix="llm_router install"))
+        print(_fail("llm_router.md — not installed", fix="llm-router install"))
         issues.append("Routing rules not installed")
 
     # ── 3. Claude Code MCP registration ────────────────────────────────────
@@ -876,7 +876,7 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
         )
         if _cc_problems:
             for _p in _cc_problems:
-                print(_fail(_p, fix="llm_router install"))
+                print(_fail(_p, fix="llm-router install"))
             issues.extend(_cc_problems)
         else:
             print(_ok("MCP server registered in ~/.claude/settings.json"))
@@ -884,7 +884,7 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
         print(
             _fail(
                 "MCP server not registered",
-                fix="llm_router install",
+                fix="llm-router install",
             )
         )
         issues.append("MCP server not registered in Claude Code")
@@ -909,7 +909,7 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
                 )
                 if _dt_problems:
                     for _p in _dt_problems:
-                        print(_fail(_p, fix="llm_router install"))
+                        print(_fail(_p, fix="llm-router install"))
                     issues.extend(_dt_problems)
                 else:
                     print(_ok(f"registered ({desktop_path})"))
@@ -1191,7 +1191,7 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
                     print(
                         _fail(
                             f"{dst_name}  — not installed",
-                            fix="llm_router install --claw-code",
+                            fix="llm-router install --claw-code",
                         )
                     )
                     issues.append(f"claw-code hook {dst_name} not installed")
@@ -1203,7 +1203,7 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
                 print(
                     _fail(
                         "MCP server not registered in claw-code",
-                        fix="llm_router install --claw-code",
+                        fix="llm-router install --claw-code",
                     )
                 )
                 issues.append("MCP server not registered in claw-code")

--- a/src/llm_router/commands/install.py
+++ b/src/llm_router/commands/install.py
@@ -52,15 +52,15 @@ def _fail(label: str, fix: str | None = None) -> str:
 # ── Command entry point ────────────────────────────────────────────────────────
 
 _INSTALL_HELP = """\
-llm_router install — install LLM Router routing into a host
+llm-router install — install LLM Router routing into a host
 
 Usage:
-  llm_router install                     Install for Claude Code (hooks + rules + MCP)
-  llm_router install --host <name>       Install/print config for a specific host
+  llm-router install                     Install for Claude Code (hooks + rules + MCP)
+  llm-router install --host <name>       Install/print config for a specific host
                                      (claude-code, claude-desktop, cursor, copilot,
                                      windsurf, gemini-cli, codex, …)
-  llm_router install --mode <mode>       Install mode (auto | gateway)
-  llm_router install --help, -h          Show this help and exit (no changes made)
+  llm-router install --mode <mode>       Install mode (auto | gateway)
+  llm-router install --help, -h          Show this help and exit (no changes made)
 """
 
 
@@ -171,7 +171,7 @@ def _run_install(flags: list[str]) -> None:
         if all_ok:
             print(_green("  Everything looks good."))
         else:
-            print(_yellow("  Run `llm_router install` to fix the issues above."))
+            print(_yellow("  Run `llm-router install` to fix the issues above."))
         print()
         return
 
@@ -221,13 +221,13 @@ def _run_install(flags: list[str]) -> None:
     print("    You'll see: ⚡ ROUTE → Haiku (simple query)\n")
 
     print(_bold("  Subcommands:"))
-    print("    llm_router doctor               — verify everything is wired up")
-    print("    llm_router status               — today's cost & savings")
-    print("    llm_router dashboard            — web dashboard (localhost:7337)")
-    print("    llm_router install --check      — preview install state")
-    print("    llm_router install --force      — reinstall / update paths")
-    print("    llm_router install --claw-code  — also install into claw-code")
-    print("    llm_router uninstall            — remove\n")
+    print("    llm-router doctor               — verify everything is wired up")
+    print("    llm-router status               — today's cost & savings")
+    print("    llm-router dashboard            — web dashboard (localhost:7337)")
+    print("    llm-router install --check      — preview install state")
+    print("    llm-router install --force      — reinstall / update paths")
+    print("    llm-router install --claw-code  — also install into claw-code")
+    print("    llm-router uninstall            — remove\n")
 
 
 # ── install --headless ─────────────────────────────────────────────────────────
@@ -257,7 +257,7 @@ def _run_install_headless() -> None:
   FROM python:3.12-slim
 
   # Install llm_router and wire in hooks
-  RUN pip install llm-routing && llm_router install
+  RUN pip install llm-routing && llm-router install
 
   # Route to API providers — no Anthropic subscription in CI
   ENV LLM_ROUTER_CLAUDE_SUBSCRIPTION=false
@@ -272,7 +272,7 @@ def _run_install_headless() -> None:
     print(snippet)
 
     print(_bold("  .claude/settings.json — MCP + hooks merge example:"))
-    print(_dim("  (llm_router install does this automatically; shown for reference)"))
+    print(_dim("  (llm-router install does this automatically; shown for reference)"))
     import json as _json
     example = {
         "mcpServers": {"llm_router": {"command": "llm-router", "args": []}},
@@ -1227,13 +1227,13 @@ def _install_host(host: str, mode: str = "auto") -> None:
         return
 
     w = shutil.get_terminal_size((80, 24)).columns
-    print(f"\n{bold}llm_router install --host {host}{reset}\n")
+    print(f"\n{bold}llm-router install --host {host}{reset}\n")
     print("─" * min(w, 70))
 
     # Hosts that write files; all others print snippets
     _FILE_WRITERS = {
         "codex":      (lambda: _install_codex_files(mode="gateway" if mode == "auto" else mode),
-                       "Restart Codex and run `llm_router doctor --host codex` to verify automatic routing."),
+                       "Restart Codex and run `llm-router doctor --host codex` to verify automatic routing."),
         "opencode":   (_install_opencode_files,     f"Restart OpenCode and run {route_tool('llm_savings')} to verify."),
         "gemini-cli": (_install_gemini_cli_files,   f"Restart Gemini CLI and run {route_tool('llm_savings')} to verify."),
         "copilot-cli":(_install_copilot_cli_files,  f"Restart Copilot CLI and run {route_tool('llm_savings')} to verify."),
@@ -1261,6 +1261,6 @@ def _install_host(host: str, mode: str = "auto") -> None:
         print("─" * min(w, 70))
 
     print(
-        f"\nFor Claude Code (hooks + full cost-routing): {bold}llm_router install{reset}\n"
+        f"\nFor Claude Code (hooks + full cost-routing): {bold}llm-router install{reset}\n"
         f"See docs/hosts/ for setup guides and trade-off explanations.\n"
     )

--- a/tests/commands/test_doctor.py
+++ b/tests/commands/test_doctor.py
@@ -177,7 +177,7 @@ class TestRunDoctorHost:
         _run_doctor_host("codex")
         output = capsys.readouterr().out
         assert "force-set to 'llm_router'" in output
-        assert "llm_router install --host codex --mode gateway" in output
+        assert "llm-router install --host codex --mode gateway" in output
 
     def test_run_doctor_host_codex_reports_not_gateway(self, capsys, tmp_path, monkeypatch):
         monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
@@ -189,7 +189,7 @@ class TestRunDoctorHost:
         output = capsys.readouterr().out
         assert "Codex using its own default model provider" in output
         assert "LLM Router model provider table missing" in output
-        assert "llm_router install --host codex --mode gateway" in output
+        assert "llm-router install --host codex --mode gateway" in output
 
     def test_run_doctor_host_all(self, capsys):
         """Test doctor checks all hosts."""

--- a/tests/test_gh66_gh67_docs_lint.py
+++ b/tests/test_gh66_gh67_docs_lint.py
@@ -37,8 +37,11 @@ with an explanation instead of silently going stale itself.
 
 from __future__ import annotations
 
+import ast
+import io
 import json
 import re
+import tokenize
 from pathlib import Path
 
 import pytest
@@ -285,3 +288,161 @@ def test_plugin_json_mcp_servers_path_exists_if_present():
         target = _REPO_ROOT / mcp_servers
         assert target.exists(), f"plugin.json's mcpServers points at {mcp_servers!r}, which does not exist"
     # A dict-shaped mcpServers is an inline config, not a path reference — nothing to check.
+
+
+# ── 7. Underscore CLI invocations inside SOURCE user-facing strings (GH#72) ──
+#
+# Section 4 above catches `llm_router <subcommand>` in docs/skills/rules, but
+# does NOT scan `src/` — which is exactly where GH#72 found it: install.py's
+# `--help` text and the Dockerfile snippet it prints, and doctor.py's own
+# `fix="llm_router ..."` remediation hints (including the bold `llm_router
+# doctor` heading the command prints about itself).
+#
+# SCOPE: this section lints only `commands/install.py` and `commands/
+# doctor.py` — the two files GH#72 named and the two this fix touches. A
+# full-`src/` sweep turns up ~130 more pre-existing hits across
+# commands/*.py, hooks/*.py, router.py, and friends; fixing those is a much
+# larger, separate cleanup and out of scope for this issue (and this branch
+# is constrained to touching only install.py/doctor.py/this test). Widening
+# `_CLI_LINT_FILES` file-by-file as each is cleaned up is the natural
+# follow-up — the moment a file is added here, this test starts guarding it
+# for free.
+#
+# THE HARD PART, mechanically: telling a PRINTED shell command apart from a
+# legitimate `import llm_router`, an MCP server dict key, or a docstring
+# narrating past behavior — without a lint so blunt everyone has to suppress
+# it. The rule has two layers:
+#
+#   1. Reuse `_UNDERSCORE_COMMAND_PATTERN` (section 4): it only fires on
+#      `llm_router` + a space + one of cli.py's real subcommand words. That
+#      alone already rejects `import llm_router` (nothing follows), a bare
+#      `"llm_router"` MCP/dict key (nothing follows), `llm_router.md` /
+#      `llm_router-auto-route.py` (a `.` or `-` follows, not a space), and
+#      `model_provider=llm_router` (an `=` follows, and it's a config VALUE,
+#      not an invocation). Only "llm_router install/doctor/status/..." shaped
+#      exactly like a shell command survives this filter.
+#   2. A survivor is excluded only if its line falls inside (a) a genuine
+#      docstring — computed with `ast`, by walking Module/FunctionDef/
+#      AsyncFunctionDef/ClassDef nodes and taking the line span of each
+#      node's leading `Expr(Constant(str))`, i.e. precisely what `__doc__`
+#      returns — or (b) a `#` comment, found with `tokenize` (comments are
+#      invisible to `ast` entirely, so tokenize is the only way to see them).
+#      Both are prose ABOUT behavior, past or present; neither is ever text
+#      the CLI itself prints. Everything else that survives layer 1 — a
+#      `print()` argument, an f-string assigned then printed, a `fix=`/
+#      `actions.append(...)` remediation message — reaches a real terminal.
+#
+# `test_docstring_and_comment_detection_tells_command_from_reference` below
+# proves this split actually works on a minimal fixture before the real
+# scan trusts it on install.py/doctor.py.
+
+_CLI_LINT_FILES = (
+    _REPO_ROOT / "src" / "llm_router" / "commands" / "install.py",
+    _REPO_ROOT / "src" / "llm_router" / "commands" / "doctor.py",
+)
+
+
+def _docstring_line_span(tree: ast.AST) -> set[int]:
+    """Every line number that belongs to a real docstring: the first
+    statement of a Module/FunctionDef/AsyncFunctionDef/ClassDef body, when
+    that statement is a bare string constant — exactly what `__doc__` picks
+    up at runtime. Comments are not visible to `ast` at all, so this can
+    never accidentally swallow one."""
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            body = getattr(node, "body", None)
+            if not body:
+                continue
+            first = body[0]
+            if (
+                isinstance(first, ast.Expr)
+                and isinstance(first.value, ast.Constant)
+                and isinstance(first.value.value, str)
+            ):
+                doc = first.value
+                end = doc.end_lineno or doc.lineno
+                lines.update(range(doc.lineno, end + 1))
+    return lines
+
+
+def _comment_line_span(src: str) -> set[int]:
+    """Every line number carrying a `#` comment token. `ast` drops comments
+    entirely, so `tokenize` — the stdlib's own source of truth for comment
+    tokens — is the only mechanical way to see them."""
+    lines: set[int] = set()
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(src).readline):
+            if tok.type == tokenize.COMMENT:
+                lines.add(tok.start[0])
+    except (tokenize.TokenizeError, IndentationError, SyntaxError):
+        pass
+    return lines
+
+
+def _underscore_cli_hits_in_source(path: Path) -> list[str]:
+    """Lines in `path` where `llm_router <subcommand>` appears as a live,
+    user-facing string — a `print()` argument, an f-string, a `fix=`/
+    `actions.append(...)` remediation message, a `--help` constant — and NOT
+    inside a docstring or `#` comment (which narrate past/other behavior
+    rather than instructing a current action)."""
+    src = _read(path)
+    if not src:
+        return []
+    tree = ast.parse(src, filename=str(path))
+    excluded = _docstring_line_span(tree) | _comment_line_span(src)
+    try:
+        label = str(path.relative_to(_REPO_ROOT))
+    except ValueError:
+        label = str(path)
+    hits = []
+    for i, line in enumerate(src.splitlines(), 1):
+        if i in excluded:
+            continue
+        if _UNDERSCORE_COMMAND_PATTERN.search(line):
+            hits.append(f"{label}:{i}: {line.strip()}")
+    return hits
+
+
+def test_cli_lint_files_exist_and_are_nonempty():
+    """Guards the guard, same purpose as test_the_scan_finds_something above:
+    an empty/missing file would make the real lint below pass vacuously."""
+    for p in _CLI_LINT_FILES:
+        assert p.is_file(), p
+        assert len(_read(p).splitlines()) > 100, f"{p} looks truncated"
+
+
+def test_docstring_and_comment_detection_tells_command_from_reference(tmp_path):
+    """Unit-level proof that the AST/tokenize split actually distinguishes a
+    PRINTED shell command from a module reference / historical narration —
+    GH#72's own warning that a lint which cannot tell them apart is worse
+    than none. All four lines below contain the literal same offending text
+    (`llm_router install`); only the `print()` one may ever surface as a hit."""
+    sample = '''"""Module docstring: `llm_router install` is what an old release told you to run."""
+
+import llm_router  # not a command — must never match on its own
+
+
+def f():
+    """`llm_router install` here too — still just prose about the past."""
+    # `llm_router install` — also just a comment, not printed
+    print("Run `llm_router install` to fix this")
+'''
+    sample_path = tmp_path / "gh72_sample.py"
+    sample_path.write_text(sample)
+
+    hits = _underscore_cli_hits_in_source(sample_path)
+
+    assert len(hits) == 1, f"expected exactly the print() line to match, got: {hits}"
+    assert 'print("Run `llm_router install` to fix this")' in hits[0]
+
+
+def test_no_underscore_cli_invocations_in_install_and_doctor_source():
+    hits: list[str] = []
+    for p in _CLI_LINT_FILES:
+        hits.extend(_underscore_cli_hits_in_source(p))
+    assert not hits, (
+        "`llm_router <subcommand>` used as a printed/user-facing CLI "
+        "instruction in source (the real CLI binary is `llm-router`; "
+        "underscore is the Python module / MCP key):\n" + "\n".join(hits)
+    )


### PR DESCRIPTION
Closes #72

37 user-facing strings told people to run `llm_router <cmd>` — 18 in `install.py`, 19 in `doctor.py`. The installed binary is `llm-router`; `llm_router` is the Python module and is not on `$PATH`.

Two stand out:

- **`install.py`'s headless Dockerfile snippet.** A copy-pasted `RUN pip install llm-routing && llm_router install` fails at the second command in any CI image built from the documented instructions.
- **`doctor.py`'s remediation hints.** Every failing check printed a `fix=` naming a command that does not exist — including the heading doctor prints about *itself*. A diagnostic tool whose advice cannot be run is worse than one that says nothing.

## The lint, and the part that actually needed thought

The #66/#67 lint covered `guide/`, `skills/`, `rules/` and `docs/` but not `src/`. It now covers these two files.

The hard part is telling a **printed shell command** from a legitimate `import llm_router`, because all three names are real and must survive: package `llm-routing`, binary `llm-router`, module/MCP key `llm_router`. A lint that cannot tell them apart is worse than none, and one everyone suppresses gets ignored. Two layers, both derived rather than hardcoded:

1. The existing `_UNDERSCORE_COMMAND_PATTERN`, built from `cli.py::_KNOWN_SUBCOMMANDS`, fires only on `llm_router` + space + a real subcommand. What *follows* the name rejects `import llm_router` (nothing), the `"llm_router"` MCP registration key (nothing), `llm_router.md` (a dot), and `model_provider=llm_router` (an equals — a config value, not an invocation).
2. Survivors are excluded if `ast` places the line inside a docstring, or `tokenize` places it inside a comment (comments being invisible to `ast`). What remains is a live `print()`, an f-string that gets printed, or a `fix=` string.

A unit test proves the distinction on a fixture containing the identical offending text in a module docstring, an import, a function docstring, a comment, and a `print()` — asserting exactly one hit, the `print()`.

## Verification

- Before: the new lint fails listing all 37 violations, matching a manual audit exactly.
- After: 38 passed, 1 skipped.
- Mutation kill: stashing the source fix reproduces all 37; restoring clears them.

## Two things worth flagging

**`tests/commands/test_doctor.py` had the bug encoded as expected behavior.** Two assertions literally required the broken string `llm_router install --host codex --mode gateway` in doctor's output, so fixing doctor necessarily broke them. Both now expect the real command. That is outside the strict file scope, but leaving them failing would have regressed the suite to preserve a bug.

**A full `src/`-wide scan with the same rule finds ~130 more pre-existing hits** across `commands/*.py`, `hooks/*.py`, `router.py` and others. Out of scope here; the lint's file list is deliberately narrow and documented as such, and widening it is the natural follow-up. I will file that separately.

Left alone deliberately, each verified: docstrings narrating past behavior (`install.py` 435, 455-463, 724-857, 1188; `doctor.py` 307, 1297), a comment (`doctor.py` 239), MCP registration keys, `import llm_router` inside a printed `python3 -c` snippet, and Copilot's `@llm_router` mention syntax.

The remaining local failures are the #74 family, unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112d4uPHtwLAoThVHZxKtwE