### PR TITLE
Stop litellm loading an ancestor .env into the process (#74)

### DIFF
--- a/src/llm_router/providers.py
+++ b/src/llm_router/providers.py
@@ -19,9 +19,27 @@ Safety invariants (Phase B):
 
 from __future__ import annotations
 
+import os
 import time
 from collections.abc import AsyncIterator
 from typing import TypedDict
+
+# GH-74: litellm's own __init__.py unconditionally calls ``dotenv.load_dotenv()``
+# (no path) the first time it is imported, unless ``LITELLM_MODE`` is already set
+# to something other than "DEV" (its default). ``load_dotenv()`` with no
+# arguments does an *upward filesystem search* from litellm's own install
+# location (deep inside site-packages), not from this repo or from ``$HOME`` —
+# so on a machine where any ancestor directory of the venv happens to contain a
+# ``.env`` (e.g. a developer's personal ``~/.env`` with real provider keys for
+# unrelated tools), importing litellm silently merges those keys into the real
+# process ``os.environ`` for the lifetime of the interpreter. llm_router already
+# owns its own, explicit config loading via ``RouterConfig`` (which reads
+# ``~/.llm-router/.env``); it neither needs nor wants a second, uncontrolled,
+# ancestor-directory dotenv load happening as a side effect of a third-party
+# import. Setting ``LITELLM_MODE`` before the import (without clobbering an
+# operator's explicit choice) opts out of that behaviour for good, in both
+# production and tests — see tests/test_gh74_env_hermeticity.py.
+os.environ.setdefault("LITELLM_MODE", "PROD")
 
 import litellm
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -583,6 +583,63 @@ def _reset_ollama_isolation():
                 os.environ[k] = v
 
 
+# ── Provider-key hermeticity (GH-74) ────────────────────────────────────────
+# ``RouterConfig.available_providers`` is assembled straight from process env
+# vars (see ``RouterConfig._PROVIDER_MAP``), so anything that puts a real key
+# into ``os.environ`` before a test runs changes that test's outcome — a
+# developer's shell profile exporting a personal key, a stray ancestor-
+# directory ``.env`` a *dependency* auto-loads (litellm's own ``__init__.py``
+# used to call ``dotenv.load_dotenv()`` unconditionally on first import, an
+# upward filesystem search from deep inside site-packages that has nothing to
+# do with this repo or ``$HOME`` — fixed at the source in
+# ``llm_router/providers.py`` by setting ``LITELLM_MODE=PROD`` before
+# importing litellm), or simply test-ordering leakage. None of that should be
+# able to change what a test observes.
+#
+# Five tests (three in test_t3_s2_max_wall_clock_seconds.py, two in
+# test_t4_m2_classification_allowlist.py) exercise ``route_and_call`` without
+# configuring a provider at all, so they only ever passed because CI happens
+# to export a dummy ``OPENAI_API_KEY`` at the job level (see
+# .github/workflows/ci.yml) — on a clean local checkout with no such export
+# (and, before the litellm fix above, with a personal ``~/.env`` leaking a
+# real ``XAI_API_KEY`` in instead) they failed with "No providers available".
+# A suite whose result depends on which ambient key happens to exist gives no
+# reliable signal either way — see tests/test_gh74_env_hermeticity.py, which
+# pins this property directly.
+
+
+@pytest.fixture(autouse=True)
+def _isolate_provider_api_keys(monkeypatch):
+    """Give every test a deterministic provider configuration, ambient-free.
+
+    Clears every env var ``RouterConfig`` or litellm could read a provider key
+    from (both the pydantic field's own env var, e.g. ``PERPLEXITY_API_KEY``,
+    and the distinct litellm-facing name where it differs, e.g.
+    ``PERPLEXITYAI_API_KEY``), then sets exactly one deterministic provider —
+    ``OPENAI_API_KEY=test-key``, matching the existing ``mock_env``/
+    ``minimal_env`` convention elsewhere in this file — so
+    ``available_providers`` is always ``{"openai"}`` unless a test explicitly
+    overrides it. A test's own ``monkeypatch.setenv``/``no_providers_env``/
+    ``minimal_env`` call runs after this fixture's setup (autouse fixtures
+    apply first) and therefore wins, so nothing that already configures its
+    own providers is affected.
+    """
+    import llm_router.config as config_module
+
+    # ``_PROVIDER_MAP`` is a leading-underscore class attribute on a pydantic
+    # BaseSettings model, so pydantic treats it as a private-attribute
+    # descriptor rather than a plain class dict — ``RouterConfig._PROVIDER_MAP``
+    # returns a ``ModelPrivateAttr`` wrapper, not the mapping. Every existing
+    # caller therefore reads it off an *instance* (``self._PROVIDER_MAP``);
+    # this fixture has none, so it unwraps the same default the descriptor
+    # would hand any instance.
+    provider_map = config_module.RouterConfig.__private_attributes__["_PROVIDER_MAP"].default
+    for field_name, (_, litellm_var) in provider_map.items():
+        monkeypatch.delenv(field_name.upper(), raising=False)
+        monkeypatch.delenv(litellm_var, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+
 @pytest.fixture(autouse=True)
 def _reset_quality_store():
     """Reset the module-global quality-feedback store before and after each test.

--- a/tests/test_gh74_env_hermeticity.py
+++ b/tests/test_gh74_env_hermeticity.py
@@ -1,0 +1,205 @@
+"""GH-74 pin: importing ``llm_router.providers`` must not let litellm's
+implicit ``dotenv.load_dotenv()`` splice ancestor-directory secrets into the
+real process environment.
+
+Root cause: ``litellm/__init__.py`` calls ``dotenv.load_dotenv()`` (no path
+argument) on first import, unless ``LITELLM_MODE`` is already set to
+something other than its "DEV" default. ``load_dotenv()`` with no path calls
+python-dotenv's ``find_dotenv()``, which does an *upward filesystem search*
+starting from the caller's own source file -- i.e. from litellm's install
+location deep inside site-packages, not from this repo and not from
+``$HOME`` -- so on any machine where an ancestor directory of the venv
+happens to hold a ``.env`` (a developer's personal ``~/.env``, or -- as this
+test proves -- even the repo root itself), importing litellm quietly mutates
+the real ``os.environ`` for the rest of the interpreter's life.
+
+That is what made ``tests/test_t3_s2_max_wall_clock_seconds.py`` and
+``tests/test_t4_m2_classification_allowlist.py`` fail on a clean local
+checkout while passing in CI: on the reporting developer's machine, a
+personal ``~/.env`` with a real ``XAI_API_KEY`` sits above this repo's
+``.venv``, so ``RouterConfig.available_providers`` ended up as ``{"xai"}``
+purely from that accidental import-order side effect -- not from anything
+the test, the shell, ``$HOME``, or ``RouterConfig`` itself did. CI has no
+such ancestor ``.env``, so it never saw the leak.
+
+Fix: ``llm_router/providers.py`` sets ``LITELLM_MODE=PROD`` (via
+``os.environ.setdefault``, so an operator's own explicit choice always wins)
+before importing litellm, opting out of litellm's ambient dotenv load
+entirely -- both in production and in tests.
+
+Both tests below run the probe as a real ``.py`` *file* in a subprocess,
+never via ``python -c``. That distinction is load-bearing: python-dotenv's
+``find_dotenv()`` only does the upward walk from the caller's real source
+file when ``__main__`` has a ``__file__`` attribute; under ``python -c``,
+``__main__`` has none, so ``find_dotenv()`` silently falls back to
+``os.getcwd()`` instead -- a completely different, CWD-driven code path that
+would validate the wrong mechanism (and, for
+``test_available_providers_unaffected_by_ancestor_dotenv``, would rig the
+test to pass regardless of the fix, since ``tmp_path`` is nowhere near the
+ancestor ``.env``). A real invocation of ``pytest`` -- and therefore of every
+test this issue is about -- always has a ``__main__.__file__``, so the
+frame-walk path is the one that matters.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_MARKER_VALUE = "gh74-ancestor-dotenv-marker-should-never-leak"
+
+
+def _clean_subprocess_env() -> dict[str, str]:
+    """A copy of this process's env with every provider-key var removed.
+
+    Stripping only ``XAI_API_KEY`` is not enough: this test file runs inside
+    a pytest session where tests/conftest.py's own GH-74 autouse fixture
+    (``_isolate_provider_api_keys``) sets ``OPENAI_API_KEY=test-key`` on the
+    real ``os.environ`` for the duration of every test (that is how
+    ``monkeypatch.setenv`` works). Without stripping the full provider set, a
+    subprocess spawned from inside a test would inherit that fixture's
+    ``OPENAI_API_KEY`` and no longer be a clean baseline -- exactly the kind
+    of ambient-state confound this whole issue is about.
+    """
+    import llm_router.config as config_module
+
+    provider_map = config_module.RouterConfig.__private_attributes__["_PROVIDER_MAP"].default
+    strip = set()
+    for field_name, (_, litellm_var) in provider_map.items():
+        strip.add(field_name.upper())
+        strip.add(litellm_var)
+    return {k: v for k, v in os.environ.items() if k not in strip}
+
+
+def _run_script(code: str, *, cwd: Path, script_dir: Path) -> subprocess.CompletedProcess:
+    """Run ``code`` as a real ``.py`` file (never ``python -c``) in a
+    subprocess with a fully scrubbed provider-key environment.
+
+    ``script_dir`` is where the throwaway script file itself lives (its
+    ``__file__`` is what python-dotenv's ``find_dotenv`` would walk up from
+    if IT were the caller -- it never is here, litellm is -- so this choice
+    doesn't affect what's under test); ``cwd`` is the subprocess's working
+    directory, which only matters for ``RouterConfig``'s own separate
+    CWD-relative ``env_file`` entry, not for litellm's mechanism.
+    """
+    script_path = script_dir / "probe.py"
+    script_path.write_text(textwrap.dedent(code))
+    return subprocess.run(
+        [sys.executable, str(script_path)],
+        cwd=str(cwd),
+        env=_clean_subprocess_env(),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+@pytest.fixture
+def ancestor_dotenv():
+    """Create ``<repo root>/.env`` with a marker key; remove it afterward.
+
+    Skips (never overwrites) if a real ``.env`` is already present at the
+    repo root -- only ``.env.example`` is meant to be tracked there, but this
+    must never clobber a developer's real file if one exists.
+    """
+    env_path = REPO_ROOT / ".env"
+    if env_path.exists():
+        pytest.skip(f"{env_path} already exists; refusing to overwrite a real file")
+    env_path.write_text(f"XAI_API_KEY={_MARKER_VALUE}\n")
+    try:
+        yield env_path
+    finally:
+        env_path.unlink(missing_ok=True)
+
+
+def test_importing_providers_does_not_leak_ancestor_dotenv_into_os_environ(
+    ancestor_dotenv: Path, tmp_path: Path
+) -> None:
+    """The GH-74 hermeticity property, pinned directly against the real
+    mechanism: importing ``llm_router.providers`` (and therefore litellm)
+    must never mutate ``os.environ`` from a ``.env`` file that sits above the
+    installed package in the filesystem.
+
+    Without the fix, litellm's unconditional ``load_dotenv()`` walks up from
+    its own install location, crosses the repo root, finds the fixture's
+    ``.env`` there, and injects ``XAI_API_KEY`` into the subprocess's real
+    ``os.environ`` -- exactly the mechanism that produced
+    ``Configured providers: {'xai'}`` in GH-74. The probe's own CWD
+    (``tmp_path``, outside the repo) is deliberately *not* where the marker
+    lives, so a pass here can only be explained by litellm's own mechanism
+    being neutralized -- not by accidentally missing the file some other way.
+
+    Mutation check: reverting the ``LITELLM_MODE`` line in
+    ``llm_router/providers.py`` makes this test fail (the marker key leaks
+    through); restoring it makes it pass again -- verified by hand.
+    """
+    result = _run_script(
+        """
+        import os, sys
+        assert "XAI_API_KEY" not in os.environ, "harness leaked XAI_API_KEY into the subprocess before import"
+        import llm_router.providers  # noqa: F401 -- triggers litellm's own import, unguarded
+        leaked = os.environ.get("XAI_API_KEY")
+        print("LEAKED=" + repr(leaked))
+        sys.exit(1 if leaked else 0)
+        """,
+        cwd=tmp_path,
+        script_dir=tmp_path,
+    )
+    assert result.returncode == 0, (
+        "importing llm_router.providers leaked the ancestor .env's XAI_API_KEY "
+        "into os.environ -- litellm's implicit dotenv auto-load is not "
+        f"neutralized. stdout={result.stdout!r} stderr={result.stderr[-2000:]!r}"
+    )
+
+
+def test_available_providers_unaffected_by_ancestor_dotenv(
+    ancestor_dotenv: Path, tmp_path: Path
+) -> None:
+    """End-to-end version of the same property, through the exact code path
+    GH-74 actually broke: ``RouterConfig.available_providers`` inside a
+    fresh process that imports the router (and therefore litellm) with the
+    ancestor ``.env``'s ``XAI_API_KEY`` present and no other provider
+    configured. Before the fix this includes ``"xai"``; after, it does not.
+
+    The probe's CWD is ``tmp_path`` -- outside the repo -- specifically so
+    ``RouterConfig.model_config['env_file']``'s own second, bare-relative
+    ``'.env'`` entry (which pydantic-settings resolves against the process
+    CWD, a real, separate, and long-standing hermeticity wrinkle that
+    predates GH-74 and is arguably an intentional "project-local .env"
+    convenience for CLI users) cannot also pick up the fixture's repo-root
+    ``.env`` and confound the result. This isolates exactly the litellm
+    auto-load path -- the same isolation the first test achieves by scrubbing
+    ``os.environ`` directly instead of relying on CWD.
+
+    Mutation check: reverting the ``LITELLM_MODE`` line in
+    ``llm_router/providers.py`` makes this test fail with
+    ``PROVIDERS={'xai'}``; restoring it makes it pass again -- verified by
+    hand (a strict subset-check, not blank-set equality, avoids coupling
+    this to unrelated ambient providers like a locally-running Ollama).
+    """
+    result = _run_script(
+        """
+        import os, sys
+        # Must go through the router (which imports llm_router.providers, which
+        # imports litellm) -- llm_router.config alone never imports litellm, so
+        # constructing a bare RouterConfig() would never exercise this
+        # mechanism at all (see llm_router/router.py's own import chain).
+        import llm_router.router  # noqa: F401
+        from llm_router.config import RouterConfig
+        providers = RouterConfig().available_providers
+        print("PROVIDERS=" + repr(providers))
+        sys.exit(1 if "xai" in providers else 0)
+        """,
+        cwd=tmp_path,
+        script_dir=tmp_path,
+    )
+    assert result.returncode == 0, (
+        "RouterConfig().available_providers picked up the ancestor .env's "
+        f"XAI_API_KEY via litellm's implicit dotenv load: stdout={result.stdout!r} "
+        f"stderr={result.stderr[-2000:]!r}"
+    )


### PR DESCRIPTION
Closes #74

I filed #74 with the root cause explicitly marked **OPEN**, having ruled out the shell environment, `$HOME`, and `RouterConfig` but declined to guess further. The actual cause was none of those, and it is materially more serious than the test failures that surfaced it.

## Root cause

`litellm/__init__.py` calls `dotenv.load_dotenv()` unconditionally at import time when `LITELLM_MODE` is unset — and it defaults to `"DEV"`:

```python
if os.getenv("LITELLM_MODE", "DEV") == "DEV":
    _dotenv.load_dotenv()
```

`load_dotenv()` with no argument calls python-dotenv's `find_dotenv()`, which walks upward from **the caller's own source file** — litellm's `__init__.py`, deep inside `.venv/lib/python3.12/site-packages/litellm/` — not from the working directory. On a developer machine that walk climbs clean out of the project and can reach a personal `~/.env`, whose contents are merged into `os.environ` for the life of the interpreter.

## Why this is not just a test bug

Merely importing `llm_router.providers` pulled a real API key out of a file **unrelated to this repository** and into the process environment. Verified directly:

```
$ env -u XAI_API_KEY python leaktest.py     # before the fix
before import, XAI_API_KEY in env: False
after  import, XAI_API_KEY in env: True     # <-- from ~/.env
```

With the fix, `False` both times.

Any credential in any `.env` **above the virtualenv** was being loaded into the process without the operator asking for it. The five failing tests were a symptom; this is the bug.

## The fix

`os.environ.setdefault("LITELLM_MODE", "PROD")` before importing litellm — suppresses the implicit load while still honoring an operator's own explicit `LITELLM_MODE`.

Defence in depth in the suite: a new autouse fixture scrubs every var in `RouterConfig._PROVIDER_MAP` and sets a deterministic baseline, so no test result can depend on ambient host state from any source, present or future. **Each half independently repairs the five tests** — neither is masking the other, which was checked explicitly.

## Verification

- Before: the repro from the issue → 5 failures, `Configured providers: {'xai'}`.
- After: all 5 pass, **with zero changes to those five tests**.
- Mutation kill (re-run independently): reverting only the `LITELLM_MODE` line makes the import leak the key again; restoring it stops the leak.
- Full suite clean, no regressions from the new autouse fixture.

The two new regression tests drive a real ancestor `.env`, a real subprocess and a real litellm import rather than mocking it — a mock would pass whether or not the leak existed. They must run from a `.py` file rather than `python -c`, because `find_dotenv()` only falls back to the working directory under `-c` and would miss the real code path.

## Notes

- **Why CI passed:** no such ancestor `.env` on the runner, and CI separately exports a dummy `OPENAI_API_KEY` — so those five tests, which never configure a provider themselves, passed for an unrelated reason.
- **The `env_file` lead in my issue was real but not the cause.** `RouterConfig.model_config['env_file']` ending in a relative `'.env'` is a separate, currently-dormant hazard (there is no `.env` at the repo root or in `~/.llm-router/`). Left untouched and flagged rather than silently folded in.
- **Not the same mechanism as #69**, which is a pydantic-settings `ValidationError` under `LLM_ROUTER_PROFILE=enterprise`. #69 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112d4uPHtwLAoThVHZxKtwE