### PR TITLE
Anchor the today-cutoff fixture to the day boundary (#79)

### DIFF
--- a/tests/test_dashboard_scope.py
+++ b/tests/test_dashboard_scope.py
@@ -158,12 +158,24 @@ def test_routing_logic_uses_today_cutoff(fake_state_dir, monkeypatch):
     )
 
     # Three rows: two today, one yesterday.
+    #
+    # GH#79: the "today" rows are anchored to start_of_day, NOT to `now`.
+    # They used to be `now - 5` and `now - 100`, which silently assumed the
+    # suite runs more than 100 seconds after local midnight. Inside that
+    # window `now - 100` falls into yesterday, gets correctly excluded, and
+    # the assertion below fails -- which is exactly what happened on a CI
+    # run that started at 23:58 UTC. Anchoring to the day boundary makes the
+    # fixture describe the behaviour under test rather than the wall clock.
+    # Both values are clamped so they never exceed `now` on a run that
+    # starts within a minute of midnight.
+    today_early = min(start_of_day + 1, now)
+    today_later = min(start_of_day + 60, now)
     _seed_tracking_jsonl(
         tracking,
         [
-            {"timestamp": now - 5, "classification_method": "heuristic",
+            {"timestamp": today_later, "classification_method": "heuristic",
              "classification_confidence": 1.0},
-            {"timestamp": now - 100, "classification_method": "heuristic-weak",
+            {"timestamp": today_early, "classification_method": "heuristic-weak",
              "classification_confidence": 0.5},
             {"timestamp": start_of_day - 3600, "classification_method": "ollama",
              "classification_confidence": 0.9},  # yesterday — must be excluded


### PR DESCRIPTION
Closes #79

`test_routing_logic_uses_today_cutoff` seeded its two "today" rows at `now - 5` and `now - 100`, quietly assuming the suite runs **more than 100 seconds after local midnight**. Inside that window the second row falls into yesterday, `_query_routing_logic` correctly excludes it, and the assertion fails:

```
AssertionError: assert 'heuristic-weak' in {'heuristic': 1}
```

**How it surfaced:** CI run 33343177979 started at `23:58:01Z`. Both `test (3.11)` and `test (3.13)` crossed midnight mid-run and both failed — on #78, a PR touching only `install.py`, `doctor.py` and two unrelated test files. That is also why it had never been seen: it needs a run straddling midnight in the runner's local time.

## Fix

The rows are anchored to `start_of_day`, clamped so they can never exceed `now` on a run starting within a minute of midnight. The fixture now describes the behaviour under test — filtering by start-of-day rather than by session start — instead of depending on when the suite happens to run.

## Verification

Replaying both the old and new arithmetic at a simulated `00:00:30` local:

```
OLD (now-anchored)     at 00:00:30 local: FAIL -> saw {'heuristic'}
NEW (day-anchored)     at 00:00:30 local: PASS
```

The old result is exactly the failure CI reported, which is the point — the reproduction matches the observed symptom rather than merely resembling it. `freezegun` is not a dependency of this project, so the clock is replayed arithmetically rather than by adding one for a single test.

Widening the window instead of removing the dependency was considered and rejected: that is the same bug with a smaller blast radius.

Same family as the Group B bug fixed in #77 (a test depending on the wall clock rather than on the behaviour under test), but a distinct instance in a different file — three such bugs have now turned up in this suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112d4uPHtwLAoThVHZxKtwE