### PR TITLE
An unrecognized LLM_ROUTER_PROFILE must not stop the server booting (#69)

### DIFF
--- a/src/llm_router/config.py
+++ b/src/llm_router/config.py
@@ -22,7 +22,7 @@ import urllib.request
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings
 
 from llm_router.paths import state_path
@@ -127,6 +127,65 @@ def validate_ollama_url(url: str) -> str:
     if host.startswith("169.254.") or host.startswith("fe80:") or "169.254.169.254" in host:
         return ""
     return url
+
+
+# ── GH#69: LLM_ROUTER_PROFILE collision, third reader ──────────────────────
+#
+# ``RouterConfig.llm_router_profile`` is the field that actually drives live
+# routing (router.py, orchestrator.py, state.py, tools/routing.py, the
+# dashboard, ...) — unlike ``repo_config.RepoConfig.effective_profile()``,
+# whose only caller is the ``llm_router config`` display (GH#65 fixed THAT
+# reader by adding ``LLM_ROUTER_COST_PROFILE`` with a value-domain-filtered
+# fallback to the legacy name). This field is a THIRD, independent reader:
+# pydantic-settings binds it to ``LLM_ROUTER_PROFILE`` purely by naming
+# convention and validates it strictly against ``RoutingProfile`` — so any
+# value outside the six routing tiers (most notably ``enterprise``/
+# ``developer``, which are ``llm_router.profile`` / ``identity.py``'s
+# UNRELATED deployment-identity axis) raised ``pydantic_core.ValidationError``
+# at ``RouterConfig()`` construction time, which server.py triggers at
+# IMPORT time — so the MCP server could not boot at all under the one env
+# value historically documented to select the enterprise profile.
+#
+# Fix: apply the same value-domain filter GH#65 established, extended so
+# this field (the one that matters for real routing) finally honors
+# ``LLM_ROUTER_COST_PROFILE`` too, with precedence over the legacy name —
+# via ``validation_alias`` below — and a ``mode="before"`` validator that
+# NEVER raises for an unrecognized value: it warns once and falls back to
+# the default profile instead. A value that is merely unrecognized must
+# not prevent the server from starting.
+_VALID_LLM_ROUTER_PROFILES = {p.value for p in RoutingProfile}
+_llm_router_profile_fallback_warning_emitted = False
+
+
+def _maybe_emit_llm_router_profile_fallback_warning(value: str) -> None:
+    """One-shot stderr warning when ``llm_router_profile`` falls back.
+
+    Mirrors the latch pattern in ``llm_router.profile`` /
+    ``llm_router.repo_config`` (``_maybe_emit_legacy_warning`` /
+    ``_maybe_emit_legacy_cost_profile_warning``) so a long-running process
+    emits the message once rather than on every ``RouterConfig()`` build.
+    """
+    global _llm_router_profile_fallback_warning_emitted
+    if _llm_router_profile_fallback_warning_emitted:
+        return
+    _llm_router_profile_fallback_warning_emitted = True
+    import sys
+    sys.stderr.write(
+        f"[llm_router] WARNING: LLM_ROUTER_PROFILE (or LLM_ROUTER_COST_PROFILE) "
+        f"is set to {value!r}, which is not a valid routing tier "
+        f"({sorted(_VALID_LLM_ROUTER_PROFILES)}). Falling back to the default "
+        f"profile ({RoutingProfile.BALANCED.value!r}) instead of crashing. "
+        "If you meant the deployment-identity axis (developer/enterprise), "
+        "set LLM_ROUTER_DEPLOYMENT_PROFILE instead (see llm_router.profile). "
+        "If you meant a routing cost tier, use LLM_ROUTER_COST_PROFILE and "
+        "rename/remove the stale LLM_ROUTER_PROFILE (GH#65/GH#69).\n"
+    )
+
+
+def _reset_llm_router_profile_fallback_warning_latch() -> None:
+    """Test affordance — reset the one-shot latch. Not part of the public API."""
+    global _llm_router_profile_fallback_warning_emitted
+    _llm_router_profile_fallback_warning_emitted = False
 
 
 class RouterConfig(BaseSettings):
@@ -261,7 +320,46 @@ class RouterConfig(BaseSettings):
     replicate_api_token: str = ""   # Replicate — various models
 
     # ── Router settings ──
-    llm_router_profile: RoutingProfile = RoutingProfile.BALANCED
+    # GH#69 (see the block above the class): reads LLM_ROUTER_COST_PROFILE
+    # first (GH#65's de-collided name), then falls back to the legacy
+    # LLM_ROUTER_PROFILE — validated below so neither name can crash
+    # construction when it holds a value outside the routing-tier domain.
+    llm_router_profile: RoutingProfile = Field(
+        default=RoutingProfile.BALANCED,
+        validation_alias=AliasChoices("LLM_ROUTER_COST_PROFILE", "LLM_ROUTER_PROFILE"),
+    )
+
+    @field_validator("llm_router_profile", mode="before")
+    @classmethod
+    def _validate_llm_router_profile(cls, v: object) -> object:
+        """Never let an unrecognized value crash config construction (GH#69).
+
+        A stale ``LLM_ROUTER_PROFILE=enterprise`` (or any other garbage
+        string — this must not special-case ``"enterprise"``) is not a
+        routing tier; raising here took down ``RouterConfig()`` at import
+        time and therefore the whole MCP server. Fall back to the default
+        profile with a one-shot warning instead.
+        """
+        if v is None or isinstance(v, RoutingProfile):
+            return v
+        s = str(v).strip()
+        if not s:
+            return v
+        if s.lower() in _VALID_LLM_ROUTER_PROFILES:
+            return s.lower()
+        # `v` came from whichever alias AliasChoices picked FIRST BY
+        # PRESENCE (LLM_ROUTER_COST_PROFILE if set at all, else the legacy
+        # name) — not by validity. So an invalid LLM_ROUTER_COST_PROFILE
+        # must still give the legacy LLM_ROUTER_PROFILE its own chance
+        # before giving up, exactly mirroring the two-step check in
+        # repo_config.effective_profile() (GH#65).
+        import os
+        legacy = os.environ.get("LLM_ROUTER_PROFILE", "").strip().lower()
+        if legacy and legacy != s.lower() and legacy in _VALID_LLM_ROUTER_PROFILES:
+            return legacy
+        _maybe_emit_llm_router_profile_fallback_warning(s)
+        return RoutingProfile.BALANCED
+
     llm_router_tier: Tier = Tier.FREE
     # RED2-07: a default_factory, not a bare default. As a bare default this
     # expression ran at CLASS-DEFINITION time, freezing the real home directory
@@ -445,6 +543,17 @@ class RouterConfig(BaseSettings):
         "env_file": (Path.home() / ".llm-router" / ".env", ".env"),
         "env_file_encoding": "utf-8",
         "extra": "ignore",
+        # GH#69: llm_router_profile sets an explicit validation_alias
+        # (AliasChoices) to read LLM_ROUTER_COST_PROFILE ahead of the legacy
+        # LLM_ROUTER_PROFILE name. Without populate_by_name, an explicit
+        # validation_alias also stops the plain field name from being
+        # accepted as a constructor kwarg — every OTHER field in this class
+        # is still constructible by field name (`RouterConfig(foo_bar=...)`,
+        # as the existing test suite does throughout), so this keeps
+        # `RouterConfig(llm_router_profile=...)` working the same way
+        # rather than silently ignoring the kwarg and falling back to the
+        # default profile.
+        "populate_by_name": True,
     }
 
     # Maps each Pydantic field name to (provider_name, litellm_env_var).

--- a/src/llm_router/server.py
+++ b/src/llm_router/server.py
@@ -224,10 +224,11 @@ def _render_router_status(
     the SEC-004 contract (enterprise + no valid identity →
     redacted; everything else → full).
 
-    Crucially the gate check happens BEFORE we touch ``get_config``
-    so a Pydantic-rejected ``LLM_ROUTER_PROFILE`` value (llm_router's
-    Config schema predates the enterprise profile axis introduced
-    in slice 3) can't crash the redacted path."""
+    Crucially the gate check happens BEFORE we touch ``get_config`` so a
+    ``RouterConfig()`` construction failure (GH#69 fixed the one specific
+    cause that used to bite here — see the ``except`` below — but this
+    still guards against any other unrelated config validation error)
+    can't crash the redacted path."""
     if force_redacted is None:
         from llm_router.profile import is_enterprise
         from llm_router.identity import (
@@ -261,30 +262,32 @@ def _render_router_status(
     try:
         config = get_config()
     except Exception:
-        # Routing config failed to validate. Most likely cause (GH#65):
-        # ``LLM_ROUTER_PROFILE`` is set to a deployment-profile value
-        # (``developer``/``enterprise``) but the routing ``RouterConfig``
-        # (pydantic-settings) still binds its ``llm_router_profile`` field
-        # to that same env name and requires one of ``budget/balanced/
-        # premium/reasoning/quota_balanced/subscription_local`` — so a
-        # deployment-profile value raises a validation error here instead
-        # of being silently ignored.
+        # GH#69 fixed the specific cause this except-block used to exist
+        # for: ``RouterConfig.llm_router_profile`` (config.py) used to bind
+        # directly (by pydantic-settings naming convention) to
+        # ``LLM_ROUTER_PROFILE`` and validate it strictly against the six
+        # routing tiers — so a deployment-identity value like
+        # ``developer``/``enterprise`` (a completely different axis, see
+        # ``llm_router.profile`` / ``identity.py``) raised
+        # ``pydantic_core.ValidationError`` here. That field now applies
+        # the same value-domain filter GH#65 established for
+        # ``repo_config.RepoConfig.effective_profile()`` (reads
+        # ``LLM_ROUTER_COST_PROFILE`` first, falls back to the legacy name
+        # only when it's a genuine routing tier, and otherwise warns once
+        # and defaults instead of raising) — so THIS specific collision can
+        # no longer reach this except-block.
         #
-        # Note this is a DIFFERENT collision site than the one GH#65 fixed
-        # in ``repo_config.py``: that module's ``effective_profile()`` now
-        # reads the de-collided ``LLM_ROUTER_COST_PROFILE`` (with a
-        # value-domain-filtered legacy fallback) and never raises. This
-        # pydantic-settings field still reads the raw legacy env name
-        # directly and is NOT yet de-collided — this except-block remains
-        # the load-bearing workaround for it. Surface a useful message
-        # rather than crashing the resource handler.
+        # Left in place as generic defense: ``RouterConfig()`` can still
+        # fail to validate for reasons unrelated to the profile axis (e.g.
+        # a malformed numeric/enum env var elsewhere in the schema), and
+        # this resource must stay resilient to that too rather than
+        # crashing the redacted-status path.
         return "\n".join([
             "Profile: enterprise",
             "Status: ok",
-            "Note: routing config unavailable — the deployment-profile "
-            "env may collide with the routing config's LLM_ROUTER_PROFILE "
-            "expectations. Restart with a clean routing profile to see "
-            "provider details.",
+            "Note: routing config unavailable — check your environment "
+            "for a malformed llm_router env var. Restart with a clean "
+            "environment to see provider details.",
         ])
     tracker = get_tracker()
     report = tracker.status_report()

--- a/tests/test_gh69_routerconfig_profile_crash.py
+++ b/tests/test_gh69_routerconfig_profile_crash.py
@@ -1,0 +1,236 @@
+"""GH#69 — ``RouterConfig.llm_router_profile`` (config.py) is a THIRD,
+independent reader of ``LLM_ROUTER_PROFILE``, distinct from the two GH#65
+fixed (``repo_config.RepoConfig.effective_profile()``) and the deployment-
+identity axis (``llm_router.profile`` / ``identity.py``).
+
+Unlike ``effective_profile()`` (display-only — its only caller is
+``llm_router config``), this pydantic-settings field is the LIVE routing
+profile consumed throughout ``router.py``, ``orchestrator.py``, ``state.py``,
+``tools/routing.py`` and the dashboard. Before this fix, pydantic-settings
+bound it directly (by naming convention) to ``LLM_ROUTER_PROFILE`` and
+validated it strictly against the six routing tiers — so setting
+``LLM_ROUTER_PROFILE=enterprise`` (the one value historically documented to
+select the enterprise identity profile) raised
+``pydantic_core.ValidationError`` at ``RouterConfig()`` construction, which
+``server.py:146`` triggers at IMPORT time. The whole MCP server could not
+boot.
+
+#76 also removed the entire enterprise surface (``llm_router.enterprise``,
+``rbac_routing.py``, ``audit_routing.py``, ``scim_api.py``,
+``commands/verify_enterprise.py``) — it is not shipped in this package.
+``LLM_ROUTER_PROFILE=enterprise``/``LLM_ROUTER_DEPLOYMENT_PROFILE=enterprise``
+is still MEANINGFUL to ``llm_router.profile.is_enterprise()`` (it flips a few
+"strict" defaults and, since #76, ``server._startup_verify_or_die()``
+deliberately refuses to boot with a clear message rather than a crash) — but
+it is no longer a value this field should ever have tried to validate
+against routing tiers in the first place.
+
+The fix (this file tests it): apply the same value-domain filter GH#65
+established for ``repo_config.py``, extended to actually matter here since
+this field is the live reader. ``llm_router_profile`` now reads
+``LLM_ROUTER_COST_PROFILE`` first (GH#65's de-collided name), then falls back
+to the legacy ``LLM_ROUTER_PROFILE`` — but ONLY when that value is a real
+routing tier. Anything else (``enterprise``, ``developer``, a plain typo)
+never reaches pydantic's enum validator: a ``mode="before"`` validator
+intercepts it, emits a one-shot stderr warning, and substitutes the default
+profile instead of raising. The fix deliberately does NOT special-case the
+string ``"enterprise"`` — any unrecognized value is treated the same way.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from llm_router import config as config_module
+from llm_router.config import RouterConfig
+from llm_router.types import RoutingProfile
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_ENTRY_POINT = Path(sys.executable).with_name("llm-router")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("LLM_ROUTER_PROFILE", raising=False)
+    monkeypatch.delenv("LLM_ROUTER_COST_PROFILE", raising=False)
+    config_module._reset_llm_router_profile_fallback_warning_latch()
+
+
+# ── 1. The exact crash from the issue must be gone ──────────────────────
+
+
+def test_stale_enterprise_value_does_not_raise(monkeypatch):
+    """The literal repro from GH#69: LLM_ROUTER_PROFILE=enterprise must not
+    raise pydantic_core.ValidationError when RouterConfig() is constructed."""
+    monkeypatch.setenv("LLM_ROUTER_PROFILE", "enterprise")
+    cfg = RouterConfig()  # pre-fix: raised here
+    assert cfg.llm_router_profile == RoutingProfile.BALANCED
+
+
+# ── 2. Must not special-case "enterprise" ───────────────────────────────
+
+
+def test_arbitrary_garbage_value_does_not_raise(monkeypatch):
+    """A value with no meaning on ANY axis (not identity, not routing) must
+    be handled identically to 'enterprise' — the fix is a value-domain
+    filter, not a hardcoded string check."""
+    monkeypatch.setenv("LLM_ROUTER_PROFILE", "xyzzy-not-a-real-profile-42")
+    cfg = RouterConfig()
+    assert cfg.llm_router_profile == RoutingProfile.BALANCED
+
+
+def test_other_identity_axis_value_also_falls_back(monkeypatch):
+    """'developer' is meaningful on the OTHER (identity) axis but is still
+    not a routing tier — must fall back exactly like 'enterprise', not be
+    coerced into some special developer-routing behavior."""
+    monkeypatch.setenv("LLM_ROUTER_PROFILE", "developer")
+    cfg = RouterConfig()
+    assert cfg.llm_router_profile == RoutingProfile.BALANCED
+
+
+# ── 3. Every genuinely valid routing tier still resolves ────────────────
+
+
+@pytest.mark.parametrize(
+    "tier",
+    ["budget", "balanced", "premium", "reasoning", "quota_balanced", "subscription_local"],
+)
+def test_every_real_tier_still_resolves_via_legacy_env(monkeypatch, tier):
+    monkeypatch.setenv("LLM_ROUTER_PROFILE", tier)
+    cfg = RouterConfig()
+    assert cfg.llm_router_profile == RoutingProfile(tier)
+
+
+@pytest.mark.parametrize(
+    "tier",
+    ["budget", "balanced", "premium", "reasoning", "quota_balanced", "subscription_local"],
+)
+def test_every_real_tier_resolves_via_cost_profile_env(monkeypatch, tier):
+    monkeypatch.setenv("LLM_ROUTER_COST_PROFILE", tier)
+    cfg = RouterConfig()
+    assert cfg.llm_router_profile == RoutingProfile(tier)
+
+
+# ── 4. LLM_ROUTER_COST_PROFILE precedence (GH#65 pattern) ───────────────
+
+
+def test_cost_profile_takes_precedence_over_legacy_profile(monkeypatch):
+    monkeypatch.setenv("LLM_ROUTER_COST_PROFILE", "budget")
+    monkeypatch.setenv("LLM_ROUTER_PROFILE", "premium")
+    cfg = RouterConfig()
+    assert cfg.llm_router_profile == RoutingProfile.BUDGET
+
+
+def test_garbage_cost_profile_falls_back_to_valid_legacy_value(monkeypatch):
+    """Mirrors GH#65's test_garbage_new_env_falls_back_to_legacy: an invalid
+    LLM_ROUTER_COST_PROFILE must not win just because it was checked first —
+    it must fall through to a genuinely valid legacy value."""
+    monkeypatch.setenv("LLM_ROUTER_COST_PROFILE", "not-a-tier")
+    monkeypatch.setenv("LLM_ROUTER_PROFILE", "premium")
+    cfg = RouterConfig()
+    assert cfg.llm_router_profile == RoutingProfile.PREMIUM
+
+
+def test_garbage_everywhere_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("LLM_ROUTER_COST_PROFILE", "not-a-tier")
+    monkeypatch.setenv("LLM_ROUTER_PROFILE", "enterprise")
+    cfg = RouterConfig()
+    assert cfg.llm_router_profile == RoutingProfile.BALANCED
+
+
+def test_default_profile_when_neither_env_set():
+    cfg = RouterConfig()
+    assert cfg.llm_router_profile == RoutingProfile.BALANCED
+
+
+# ── 5. Warning behavior: actionable, one-shot ────────────────────────────
+
+
+def test_fallback_emits_actionable_one_shot_warning(monkeypatch, capsys):
+    monkeypatch.setenv("LLM_ROUTER_PROFILE", "enterprise")
+    RouterConfig()
+    RouterConfig()
+    RouterConfig()
+    err = capsys.readouterr().err
+    assert err.count("WARNING") == 1, "warning must fire once per process, not per construction"
+    assert "enterprise" in err
+    assert "LLM_ROUTER_COST_PROFILE" in err
+    assert "LLM_ROUTER_DEPLOYMENT_PROFILE" in err
+
+
+def test_valid_tier_emits_no_warning(monkeypatch, capsys):
+    monkeypatch.setenv("LLM_ROUTER_PROFILE", "budget")
+    RouterConfig()
+    err = capsys.readouterr().err
+    assert "WARNING" not in err
+
+
+# ── 6. Regression guard: validation_alias must not break kwarg construction
+
+
+def test_direct_kwarg_construction_by_field_name_still_works():
+    """Every OTHER field in RouterConfig is constructible by its plain
+    field name (the whole test suite relies on this, e.g.
+    test_config_routing_value.py). Adding validation_alias for the
+    LLM_ROUTER_COST_PROFILE precedence must not silently break
+    `RouterConfig(llm_router_profile=...)` and fall back to the default —
+    populate_by_name is what keeps this working."""
+    cfg = RouterConfig(llm_router_profile=RoutingProfile.PREMIUM)
+    assert cfg.llm_router_profile == RoutingProfile.PREMIUM
+
+    cfg2 = RouterConfig(llm_router_profile="budget")
+    assert cfg2.llm_router_profile == RoutingProfile.BUDGET
+
+
+# ── 7. Real entry point: the actual reported crash site ─────────────────
+#
+# Driven as a real console script (never `python -c`) so the exact import
+# chain from the issue (cli.py -> server.py:146 -> get_config() ->
+# RouterConfig()) is exercised, not a synthetic stand-in.
+
+
+def _run_entry_point(extra_env: dict) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(extra_env)
+    return subprocess.run(
+        [str(_ENTRY_POINT)],
+        input=b"",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        cwd=REPO_ROOT,
+        timeout=60,
+    )
+
+
+@pytest.mark.skipif(not _ENTRY_POINT.exists(), reason="llm-router console script not installed")
+def test_real_entry_point_boots_cleanly_with_garbage_profile():
+    """The reported crash's actual failure mode: a stale/garbage
+    LLM_ROUTER_PROFILE must not prevent the server from starting at all."""
+    result = _run_entry_point({"LLM_ROUTER_PROFILE": "totally-bogus-legacy-value"})
+    stderr = result.stderr.decode("utf-8", "replace")
+    assert "ValidationError" not in stderr
+    assert "Traceback" not in stderr
+    assert result.returncode == 0, (
+        f"server failed to boot (exit {result.returncode}):\n{stderr}"
+    )
+    assert "WARNING" in stderr
+
+
+@pytest.mark.skipif(not _ENTRY_POINT.exists(), reason="llm-router console script not installed")
+def test_real_entry_point_refuses_enterprise_cleanly_not_via_crash():
+    """LLM_ROUTER_PROFILE=enterprise is still refused post-#76 (the RBAC/
+    audit/SCIM surface it would need isn't shipped) — but via
+    server._startup_verify_or_die()'s deliberate, documented message, never
+    via the pydantic crash this issue is about. Distinguishing these two
+    failure modes is the whole point of the fix: an operator gets told
+    *why*, instead of a traceback."""
+    result = _run_entry_point({"LLM_ROUTER_PROFILE": "enterprise"})
+    stderr = result.stderr.decode("utf-8", "replace")
+    assert "ValidationError" not in stderr
+    assert "Traceback" not in stderr
+    assert "not supported in this distribution" in stderr


### PR DESCRIPTION
Closes #69 — the last of the audit findings.

`RouterConfig.llm_router_profile` is bound by pydantic-settings naming convention to `LLM_ROUTER_PROFILE` and validated against the routing tiers, so `LLM_ROUTER_PROFILE=enterprise` raised `ValidationError` at **import time** via `server.py`'s `_slim = get_config().llm_router_slim` — before `_critical_modules_or_die()` or `_startup_verify_or_die()` could run. The server could not boot at all.

This was the **third** reader of that one env var. #65 fixed `repo_config.effective_profile()`, whose only caller is a display line. This field is the one that actually drives live routing, and it had never been touched.

## What `enterprise` means after #76

Worth establishing before choosing a fix, because #76 changed the answer. It is **recognized but unsupported**, not meaningless: the identity axis still knows the value, and `_startup_verify_or_die()` deliberately refuses to boot under it with an actionable message, since the RBAC/audit/SCIM surface it implies is not shipped.

So the bug was never that `enterprise` is invalid. It was that an unrelated third reader crashed **before the deliberate refusal ever got its turn** — replacing a clear "not supported in this distribution, here is what to do" with a pydantic traceback.

## The fix

`AliasChoices("LLM_ROUTER_COST_PROFILE", "LLM_ROUTER_PROFILE")` extends #65's de-collision to the reader that matters, plus a before-validator that never raises:

- valid tier → use it;
- invalid value from one alias → give the other its own chance (mirroring `effective_profile()`'s two-step check);
- still invalid → one warning naming **both** the identity axis and the cost profile, then fall back to `BALANCED`.

**Nothing special-cases the string `"enterprise"`.** Garbage values and `developer` take the identical path — the mutation matrix checks that explicitly, because special-casing one string would have passed the obvious test while leaving the actual class of bug in place.

Broadening `RoutingProfile` to accept `enterprise` was rejected outright: it would resurrect the collision #65 removed.

## Verification

Independently re-run:

```
LLM_ROUTER_PROFILE=enterprise → no crash; profile = RoutingProfile.BALANCED   (with warning)
LLM_ROUTER_PROFILE=not-a-real-tier → same path, same warning
```
Reverting `config.py` restores `pydantic_core.ValidationError: 1 validation error for RouterConfig`.

24 new tests. Mutation matrix, each mutant isolated:

| Mutant | Killed |
|---|---|
| Remove validator | 8 tests |
| Special-case only `"enterprise"` | 5 tests — proves the no-special-casing requirement |
| Drop `LLM_ROUTER_COST_PROFILE` from AliasChoices | 7 tests |
| Remove `populate_by_name` | 1 test |
| Remove one-shot latch | 1 test |
| Full revert | all 24 error — no test is tautological |

Two of the tests drive the real `.venv/bin/llm-router` console script rather than `python -c`, following the convention `test_gh74_env_hermeticity.py` established after `-c` took a different code path twice in this batch.

## Two notes

**`populate_by_name` was a regression caught in review**: `validation_alias` otherwise breaks `RouterConfig(llm_router_profile=...)` direct construction. It has its own guard test.

**`server.py`'s try/except is kept but re-scoped.** It is now structurally unreachable for this scenario, and stays as general defense against other validation failures across an 80-field schema. Its comment no longer describes a live collision that has since been fixed at the source.

One pre-existing order-dependent flake was observed in `test_session_store_concurrency.py` under random ordering — passes in isolation, reproduces identically on unmodified `main`. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112d4uPHtwLAoThVHZxKtwE