### PR TITLE
Give the concurrency test a timeout budget it can meet (#84)

### DIFF
--- a/tests/test_session_store_concurrency.py
+++ b/tests/test_session_store_concurrency.py
@@ -31,6 +31,37 @@ import multiprocessing
 import os
 from pathlib import Path
 
+import pytest
+
+# GH#84: the project-wide pytest-timeout default (`timeout = 30` in
+# pyproject.toml, mirrored by CI's `--timeout=30`) is sized for ordinary unit
+# tests, not this one. Six real forked processes doing 200 lock-serialized
+# writes apiece across 3 rounds routinely take single-digit seconds when the
+# host is idle, but pytest's own per-test SETUP already includes every
+# autouse fixture, and both setup and this test's own `_run_round` slow down
+# sharply under CPU pressure from whatever else happens to be running at the
+# time — which is exactly what pytest-randomly's shuffled ordering changes
+# from run to run. Confirmed by instrumentation: saturating the host with
+# background CPU load reproduces
+# `Failed: Timeout (>30.0s) from pytest-timeout` deterministically, with
+# `_run_round`'s own `p.join(timeout=JOIN_TIMEOUT_SECONDS)` still in flight —
+# i.e. pytest-timeout's watchdog fires and unwinds the test WHILE worker
+# processes are still writing, orphaning them and (via the enclosing
+# `tempfile.TemporaryDirectory` in the caller) deleting the directory out
+# from under them. That is indistinguishable from "writes were lost" and is
+# the actual GH#84 order-dependent flake — not corrupted/leaked
+# session_store state (instrumented and ruled out: no module-level cache or
+# singleton in session_store.py/paths.py depends on call order, and repeated
+# runs under heavy synthetic thread/CPU load with real accumulated
+# background state from a full suite pass never produced a single genuinely
+# lost marker once the timeout was removed from the equation).
+#
+# `tests/reliability/test_ledger_concurrency.py` — the other real-multiprocess
+# regression test in this suite — already carries the identical
+# `pytest.mark.timeout(180)` override for the same reason; this mirrors that
+# established precedent rather than inventing a parallel mechanism.
+pytestmark = pytest.mark.timeout(180)
+
 N_WORKERS = 6
 ITERATIONS_PER_WORKER = 200
 N_ROUNDS = 3


### PR DESCRIPTION
Closes #84

**My issue framing was wrong.** I filed this as order-dependence, grouped with the three sibling isolation bugs. It is not an isolation bug at all.

## What it actually is

`pyproject.toml` sets `timeout = 30` (mirrored by CI's `--timeout=30`), a budget sized for ordinary unit tests. This test forks **six real processes** doing 200 lock-serialized writes each across three rounds. Idle, that is 1.6s.

Under CPU pressure it is a different story. `--durations=0` measured pytest's own per-test **setup** — every autouse fixture — at **22–27 seconds on its own**, and setup plus call then crosses 30s. When pytest-timeout's watchdog fires it unwinds `_run_round()` while `p.join()` is still waiting on live workers, orphaning them, and the enclosing `TemporaryDirectory` deletes the directory they are still writing into.

The result is indistinguishable from "writes were lost" — which is why it read as a concurrency or isolation failure.

**Random ordering never leaked state into this test.** It only changed what ran immediately beforehand, and therefore how much of the 30s budget remained. That is why it looked like ordering from the outside, and why chasing a leaked singleton would have found nothing.

## Ruled out by instrumentation, not assumption

- Module-level caches in `session_store.py`, `paths.py`, `config.py` — all resolved at call time; `config._config` confirmed unset at fork time.
- Leaked non-daemon `aiosqlite` threads at fork time — **10–17 are genuinely alive**, which looked promising. But 300 fast fork attempts under real accumulated full-suite state, plus 150 against continuously busy live connections, produced **zero** lost writes.

## The reproduction is load-based, not seed-based

Nine full-suite runs across seeds 1–5, 10–13, 20–21 never reproduced it directly; the window is narrow. Saturating the host with background CPU work reproduces it deterministically:

| | Without fix | With fix |
|---|---|---|
| Isolated | passes (1.6s) | passes (1.6s) |
| Under 300-process CPU load | **FAILED 3/3** (timeout) | **passed 2/2** (33–35s vs 180s budget) |
| Mutation kill | revert → fails again | restore → passes |

## The fix

`pytestmark = pytest.mark.timeout(180)`, mirroring the **identical override already carried** by `tests/reliability/test_ledger_concurrency.py` — the suite's other real-multiprocess regression test. No test logic touched.

## Two further findings, filed separately rather than folded in

- **Same timeout-under-load signature** in `tests/test_built_artifact_is_complete.py` (three tests, seed 21). This budget problem is not unique to #84.
- **A host-isolation leak**: `test_auto_route_hook.py` and `test_agent_loop.py` reported `wrote installer artifacts outside its sandbox: ['home:.claude.json']` under seeds 20 and 21. Different mechanism, and a test writing to the real home directory is worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112d4uPHtwLAoThVHZxKtwE