### PR TITLE
Give the build-artifact tests a budget that fits a real build (#87)

### DIFF
--- a/tests/test_built_artifact_is_complete.py
+++ b/tests/test_built_artifact_is_complete.py
@@ -45,6 +45,20 @@ from pathlib import Path
 
 import pytest
 
+# The project-wide `timeout = 30` in pyproject.toml is sized for ordinary unit
+# tests. The `built` fixture below runs a real `uv build` (sdist + wheel):
+# ~17s on an idle host, but the subprocess itself competes for CPU under load
+# rather than pytest incurring per-test overhead (unlike #84's cause). Measured
+# at 58.9s-76.4s wall-clock under a saturated host — comfortably past the 30s
+# default and comfortably inside this budget. `--durations=0` confirms the
+# `built` fixture's setup runs exactly once per session (module-scoped, shared
+# by all three tests below), so this is one slow real operation, not repeated
+# work. Mirrors the identical override on
+# tests/reliability/test_ledger_concurrency.py and
+# tests/test_session_store_concurrency.py (#84), the suite's other
+# real-subprocess/multiprocess regression tests.
+pytestmark = pytest.mark.timeout(180)
+
 _REPO = Path(__file__).resolve().parent.parent
 _SRC = _REPO / "src" / "llm_router"
 


### PR DESCRIPTION
Closes #87

Three tests in `test_built_artifact_is_complete.py` hit the project-wide `timeout = 30` under CPU load. That default is sized for ordinary unit tests; these run a real `uv build`.

## The issue's hypothesis was wrong, and instrumentation says so

I suggested the three tests might each rebuild the package, and that a session-scoped fixture would be the better fix — genuinely faster rather than merely more tolerant.

They don't. The `built` fixture is already **module-scoped**, and `uv build` runs exactly once for the file — confirmed by `--durations=0` showing a single setup entry (16.8s idle) and near-zero call times for all three tests. A shared fixture would not have reduced wall clock for the failing scenario, so it wasn't written.

## The actual mechanism — different from #84 despite the identical error

#84 presented as order-dependence and turned out to be a timeout budget. The inverse trap applies here, and was checked rather than assumed.

Under 40-process CPU saturation, the traceback shows pytest-timeout firing **inside `subprocess.communicate` → `selectors.select`** — blocked on the live `uv build` child process. #84 was blocked in pytest's own fixture machinery, with setup alone measured at 22–27s. Same error string, different cause.

Measured `uv build` wall clock: **16.8s idle, 58.9s and 76.4s under load.** The single fixture failure then cascades to every dependent test, which is why the issue named exactly three.

| | idle | under 40-process CPU load |
|---|---|---|
| Before | passes (16.8s) | **FAILED 3/3** at the 30s boundary |
| After | passes (17.0s) | **passed** — 76.4s vs 180s budget |

Mutation kill: reverting the file reproduces the identical failure under fresh load; restoring clears it. Clean full-suite run mirroring CI's exact command (`--timeout=30 --randomly-seed=21`) exits 0.

## The global default stays at 30

Three files now carry a longer budget — ledger concurrency, session-store concurrency (#86), and this one. That is a property of *those tests* (real builds, real multiprocessing), not of the ~6,900-test suite. Raising the global default would blunt a useful hang-guard for everything else to accommodate three files, and the existing `pytestmark` override already handles them cleanly.

## Found, deliberately not fixed

`test_sdist_excludes_quarantined_tests.py` and `test_gh43_direct_execution_disclosure.py` each define their **own** module-scoped `built` fixture, so an `-m slow` run calls `uv build` three separate times. Those tests are excluded from the default addopts and from CI, so this is not what causes #87 — filing separately rather than folding an unrelated optimization into a timeout fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112d4uPHtwLAoThVHZxKtwE