### PR TITLE
Stop the sandbox guard blaming tests for another process's writes (#88)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest fixtures for all llm_router tests."""
 
+import json
 import os
 import socket as _socket
 from pathlib import Path
@@ -998,6 +999,40 @@ _REPORT_ONLY = frozenset({
     "home:.claude/settings.json",
 })
 
+# GH#88: whole-file diffing of ~/.claude.json produced failures that were not
+# reproducible from the code under test. Instrumenting every write path
+# (Path.write_text/write_bytes, builtins.open in a write mode, and
+# subprocess.run of `claude mcp add/remove`) across dozens of full-suite runs
+# at the reported seeds never once caught llm_router's own code touching the
+# real file — the *label* said "escaped its sandbox", but the mechanism,
+# checked directly, was something else: this machine runs several live Claude
+# Code sessions at once (`ps aux` shows multiple long-running MCP server
+# processes, one set per session), and each session's CLI process rewrites its
+# own bookkeeping in ~/.claude.json continuously and on its own schedule —
+# numStartups, promptQueueUseCount, cachedGrowthBookFeaturesAt, and the like.
+# Re-running the IDENTICAL command (same seed, same test order, hence the same
+# sequence of before/after snapshots) passed and failed nondeterministically,
+# which a real in-process defect — same interpreter, same order — cannot do;
+# a race against an independently-scheduled external writer can and did.
+#
+# llm_router's own installer only ever touches one slice of this file:
+# mcpServers["llm_router"] (see _install_claude_code_cli in install_hooks.py).
+# So that slice is the only part of ~/.claude.json worth diffing — comparing
+# the rest just launders a concurrent session's own writes into a false
+# "installer escaped its sandbox" failure blamed on whichever test's teardown
+# happened to sample the file at the wrong instant. Genuine escapes (a stray
+# `mcpServers.llm_router` created, or overwritten with test scaffolding) are
+# still caught; unrelated CLI churn no longer is.
+def _claude_json_mcp_slice(p: Path):
+    """The only part of ~/.claude.json llm_router's installer ever writes."""
+    try:
+        if not p.is_file():
+            return None
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "<unreadable>"
+    return data.get("mcpServers", {}).get("llm_router")
+
 
 @pytest.fixture(autouse=True)
 def _no_repo_mutation(request):
@@ -1016,8 +1051,15 @@ def _no_repo_mutation(request):
         # file it had no business touching; on another machine, or after a code
         # change, those same bytes would differ. Byte-equality would call that
         # clean and let the leak persist, which is exactly what it did.
+        #
+        # ~/.claude.json is the one exception: it is also live CLI state (see
+        # GH#88 above), so it is reduced to just the sub-tree llm_router's own
+        # installer can write, rather than diffed whole.
         out = {}
         for label, p in _targets():
+            if label == "home:.claude.json":
+                out[label] = _claude_json_mcp_slice(p)
+                continue
             try:
                 out[label] = (p.read_bytes(), p.stat().st_mtime_ns) if p.is_file() else None
             except OSError:


### PR DESCRIPTION
Closes #88

**The issue I filed was wrong, and the correction is the point: there is no sandbox escape.**

I asserted that tests write `.claude.json` into the real home directory, called it a correctness bug in the code under test, and told the investigator not to allowlist it. The first two claims do not hold.

## What was actually checked

Every plausible write path was instrumented in-process — `Path.write_text`/`write_bytes`, `builtins.open` in write modes, and `subprocess.run` of `claude mcp add/remove` — across roughly ten full-suite runs at the reported seeds. **Not once did `llm_router` code touch the real file.**

What did change, in a captured before/after pair from a run that failed: `promptQueueUseCount: 1949 → 1950`. A live Claude Code session's own bookkeeping. This machine runs several concurrently (24 `claude` processes; the file has 86 top-level keys, almost none of them ours).

**The tell was reproducibility.** The identical command — same seed, same test order, therefore the same sequence of snapshots — passed and failed on back-to-back runs. A real in-process defect cannot do that. A race against an independently scheduled external writer can, and did: whichever test's teardown sampled the file mid-write got blamed, which is exactly why it looked order-dependent.

This is the third time in this batch that a label proved wrong — #84 looked like ordering and was a timeout; #87 looked like repeated builds and was one slow build. Same discipline caught all three.

## What conftest already knew

`conftest.py`'s own comment documents this hazard verbatim: *"if the suite runs from inside a Claude Code session, that session rewrites it continuously."* The warning was there; the guard whole-file-diffed and failed unconditionally anyway.

## The fix

The installer only ever writes one slice of that file — `mcpServers["llm_router"]` (`install_hooks.py::_install_claude_code_cli`). That slice is now the only part diffed. Comparing the rest just launders a concurrent session's writes into a false escape report.

A genuine escape — a stray `mcpServers.llm_router` created, or overwritten with test scaffolding — is still caught. Every other `_HOME_INSTALL_TARGETS` / `_CWD_INSTALL_TARGETS` entry still diffs whole. **Not an allowlist entry**, which would have silenced the detector for real escapes too.

## Verification

- Before: 2 of ~10 full-suite runs at seeds 20/21 failed, nondeterministically.
- After: 6+ consecutive full-suite runs at both seeds, clean.
- Real `~/.claude.json`: `mcpServers.llm_router` byte-identical before and after all testing, while its other keys churned from live sessions throughout.
- Mutation kill, both directions: a synthetic `numStartups`-only change is flagged by the old logic and correctly ignored by the new one; a synthetic `mcpServers.llm_router` change is still caught by both. Replayed against the actual captured before/after pair from a failing run — old logic `changed=True`, new `changed=False`.

## Noted, not fixed

`.claude/settings.json` is the other `_REPORT_ONLY` entry with the same structural weakness — a whole-file diff of a file `install()` only partially owns. It simply has not flaked yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112d4uPHtwLAoThVHZxKtwE