### PR TITLE
Standalone binary, macOS signing, and the npm channel

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -84,6 +84,83 @@ jobs:
             throw "litellm data file missing — pricing will fail at runtime"
           }
 
+      # ── macOS signing and notarisation (task 36) ────────────────────────
+      #
+      # An unsigned binary triggers Gatekeeper on first run of a tool that asks
+      # for shell access. Skipping this turns the binary from an unlock into a
+      # scare, and the npm postinstall currently has to tell mac users to run
+      # `xattr -dr com.apple.quarantine` themselves.
+      #
+      # GATED ON SECRETS BEING PRESENT. A fork or a contributor without the
+      # credentials still gets a working unsigned build rather than a red X,
+      # and the step says plainly which artifacts are unsigned.
+      #
+      # Required repository secrets:
+      #   APPLE_CERT_P12        base64 of a Developer ID Application .p12
+      #   APPLE_CERT_PASSWORD   its export password
+      #   APPLE_TEAM_ID         10-character team identifier
+      #   APPLE_API_KEY_ID      App Store Connect API key id
+      #   APPLE_API_ISSUER_ID   its issuer id
+      #   APPLE_API_KEY         base64 of the .p8 private key
+      - name: Sign and notarize (macOS)
+        if: runner.os == 'macOS'
+        env:
+          CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
+          CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          API_KEY: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CERT_P12:-}" ]; then
+            echo "::warning::Apple signing secrets are not configured — "\
+                 "${{ matrix.asset }} will be UNSIGNED and Gatekeeper will "\
+                 "quarantine it on first run."
+            exit 0
+          fi
+
+          # Import the certificate into a throwaway keychain rather than the
+          # runner's login keychain, so nothing outlives this job.
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PW="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          security set-keychain-settings -lut 900 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          echo "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" \
+            -P "$CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: \
+            -k "$KEYCHAIN_PW" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN"
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+          # Sign every Mach-O inside the onedir, not just the launcher: the
+          # bundled .so files are loaded at runtime and an unsigned one fails
+          # the notarisation check for the whole archive.
+          find dist/llm-router -type f \( -name "*.so" -o -name "*.dylib" \) -print0 |
+            xargs -0 -I{} codesign --force --timestamp --options runtime \
+              --sign "Developer ID Application" {}
+          codesign --force --timestamp --options runtime \
+            --sign "Developer ID Application" dist/llm-router/llm-router
+          codesign --verify --deep --strict --verbose=2 dist/llm-router/llm-router
+
+          # Notarisation takes a zip, and the ticket is stapled to the app
+          # afterwards. A onedir has no bundle to staple, so the check that
+          # matters is Gatekeeper's assessment of the extracted tree.
+          echo "$API_KEY" | base64 --decode > "$RUNNER_TEMP/key.p8"
+          ditto -c -k --keepParent dist/llm-router "$RUNNER_TEMP/notarize.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+            --key "$RUNNER_TEMP/key.p8" \
+            --key-id "$API_KEY_ID" \
+            --issuer "$API_ISSUER_ID" \
+            --team-id "$TEAM_ID" \
+            --wait --timeout 30m
+          rm -f "$RUNNER_TEMP/key.p8"
+
+          security delete-keychain "$KEYCHAIN"
+          echo "signed and notarized: ${{ matrix.asset }}"
+
       - name: Package
         shell: bash
         run: |
@@ -91,7 +168,14 @@ jobs:
           if [ "${{ runner.os }}" = "Windows" ]; then
             7z a -tzip "../${{ matrix.asset }}.zip" llm-router
           else
-            tar -czf "../${{ matrix.asset }}.tar.gz" llm-router
+            # ditto preserves the extended attributes and symlinks codesign
+            # writes; GNU tar drops some of them and invalidates the signature.
+            if [ "${{ runner.os }}" = "macOS" ]; then
+              ditto -c -k --keepParent llm-router "../${{ matrix.asset }}.zip"
+              tar -czf "../${{ matrix.asset }}.tar.gz" llm-router
+            else
+              tar -czf "../${{ matrix.asset }}.tar.gz" llm-router
+            fi
           fi
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -1,0 +1,104 @@
+name: Standalone binary
+
+# Task 35. Removes Python as a prerequisite, which is what unblocks Cursor
+# users, Claude Desktop users, and the npm channel (task 37) — none of whom
+# reliably have a 3.11+ toolchain and none of whom will acquire one to save
+# money on tokens.
+#
+# Builds on tag, and on demand. NOT on every push: the build is ~40 s of
+# PyInstaller work per platform over a ~565 MB dependency tree, and nothing
+# downstream consumes an untagged artifact.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      upload:
+        description: "Attach artifacts to the run"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false        # one platform failing must not hide the others
+      matrix:
+        include:
+          - os: macos-14      # arm64
+            asset: llm-router-macos-arm64
+          - os: macos-13      # x86_64
+            asset: llm-router-macos-x86_64
+          - os: ubuntu-latest
+            asset: llm-router-linux-x86_64
+          - os: windows-latest
+            asset: llm-router-windows-x86_64
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          # Match the floor in pyproject. Building on a newer interpreter than
+          # the floor would produce a binary that silently requires newer
+          # bytecode semantics than the project claims to support.
+          python-version: "3.11"
+
+      - name: Install project and PyInstaller
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install . pyinstaller
+
+      - name: Build
+        run: pyinstaller --noconfirm --clean packaging/llm-router.spec
+
+      # A binary that builds and cannot run is worse than no binary: it ships,
+      # and the failure surfaces on a user's machine. These are the exact checks
+      # that caught litellm being absent from the first local build — it ran
+      # fine until something needed the pricing data.
+      - name: Smoke test (POSIX)
+        if: runner.os != 'Windows'
+        run: |
+          BIN=dist/llm-router/llm-router
+          "$BIN" --version
+          "$BIN" --help > /dev/null
+          test -f dist/llm-router/_internal/litellm/model_prices_and_context_window_backup.json \
+            || { echo "litellm data file missing — pricing will fail at runtime"; exit 1; }
+          test "$(ls dist/llm-router/_internal/llm_router/hooks/*.py | wc -l)" -gt 10 \
+            || { echo "hook scripts missing — run-hook cannot work"; exit 1; }
+          echo '{}' | "$BIN" run-hook dist/llm-router/_internal/llm_router/hooks/usage-refresh.py
+
+      - name: Smoke test (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $bin = "dist\llm-router\llm-router.exe"
+          & $bin --version
+          & $bin --help > $null
+          if (-not (Test-Path "dist\llm-router\_internal\litellm\model_prices_and_context_window_backup.json")) {
+            throw "litellm data file missing — pricing will fail at runtime"
+          }
+
+      - name: Package
+        shell: bash
+        run: |
+          cd dist
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            7z a -tzip "../${{ matrix.asset }}.zip" llm-router
+          else
+            tar -czf "../${{ matrix.asset }}.tar.gz" llm-router
+          fi
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ matrix.asset }}
+          path: |
+            ${{ matrix.asset }}.tar.gz
+            ${{ matrix.asset }}.zip
+          if-no-files-found: error
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ data/benchmarks/*.parquet
 data/corpus/*.jsonl
 data/outcomes/*.jsonl
 scripts/routerarena/data/_graded_*.json
+
+# Downloaded by the npm postinstall; never committed and never published.
+npm/vendor/

--- a/npm/bin/llm-router.js
+++ b/npm/bin/llm-router.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+'use strict';
+
+// Thin launcher: hand off to the standalone binary fetched by postinstall.
+//
+// Uses spawnSync with stdio inherited rather than exec, because llm-router is
+// an MCP stdio server — the host talks to it over stdin/stdout, and any
+// buffering or re-encoding in between corrupts the protocol. The child's exit
+// code is propagated verbatim so callers can branch on it.
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const bin = path.join(
+  __dirname,
+  '..',
+  'vendor',
+  'llm-router',
+  process.platform === 'win32' ? 'llm-router.exe' : 'llm-router'
+);
+
+if (!fs.existsSync(bin)) {
+  console.error(
+    'llm-routing: the standalone binary is missing.\n' +
+      '  This usually means postinstall was skipped (--ignore-scripts).\n' +
+      '  Reinstall with scripts enabled, or use:  pip install llm-routing\n'
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(bin, process.argv.slice(2), { stdio: 'inherit' });
+
+if (result.error) {
+  console.error(`llm-routing: could not run the binary: ${result.error.message}`);
+  process.exit(1);
+}
+
+// A child killed by a signal has a null status; report it the way a shell does.
+process.exit(result.status === null ? 1 : result.status);

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+'use strict';
+
+// postinstall: fetch the standalone binary for this platform.
+//
+// The binary is NOT vendored into the npm package. A single tarball carrying
+// four platforms would be well over a gigabyte, and npm would hand every user
+// the three they cannot run. Downloading the one that matches keeps the package
+// a few kilobytes and the install a single archive.
+//
+// Every failure here is fatal and loud. A postinstall that swallows an error
+// leaves `llm-router` on PATH as a command that does not work, and the user
+// discovers it mid-session rather than at install time.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const https = require('https');
+const { execFileSync } = require('child_process');
+
+const VERSION = require('./package.json').version;
+const REPO = 'ypollak2/llm-router';
+
+// Matches the asset names produced by .github/workflows/binary.yml. If those
+// change, this breaks loudly at install time rather than silently at run time.
+const TARGETS = {
+  'darwin-arm64': 'llm-router-macos-arm64.tar.gz',
+  'darwin-x64': 'llm-router-macos-x86_64.tar.gz',
+  'linux-x64': 'llm-router-linux-x86_64.tar.gz',
+  'win32-x64': 'llm-router-windows-x86_64.zip',
+};
+
+function fail(message, detail) {
+  console.error(`\nllm-routing: ${message}`);
+  if (detail) console.error(`  ${detail}`);
+  console.error(
+    '\n  You can install without Node instead:\n' +
+      '    pip install llm-routing\n' +
+      '\n  Or report this with your platform:\n' +
+      `    https://github.com/${REPO}/issues\n`
+  );
+  process.exit(1);
+}
+
+function download(url, dest, redirectsLeft = 5) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, { headers: { 'User-Agent': 'llm-routing-npm' } }, (res) => {
+        // GitHub release assets redirect to a signed object-store URL.
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          res.resume();
+          if (redirectsLeft === 0) return reject(new Error('too many redirects'));
+          return resolve(download(res.headers.location, dest, redirectsLeft - 1));
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+        }
+        const file = fs.createWriteStream(dest);
+        res.pipe(file);
+        file.on('finish', () => file.close(resolve));
+        file.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
+
+async function main() {
+  const key = `${process.platform}-${process.arch}`;
+  const asset = TARGETS[key];
+  if (!asset) {
+    fail(
+      `no standalone binary is published for ${key}.`,
+      'Supported: ' + Object.keys(TARGETS).join(', ')
+    );
+  }
+
+  const url = `https://github.com/${REPO}/releases/download/v${VERSION}/${asset}`;
+  const vendor = path.join(__dirname, 'vendor');
+  fs.mkdirSync(vendor, { recursive: true });
+  const archive = path.join(vendor, asset);
+
+  console.log(`llm-routing: fetching ${asset} (v${VERSION})`);
+  try {
+    await download(url, archive);
+  } catch (err) {
+    fail(`could not download the binary for ${key}.`, `${err.message}\n  ${url}`);
+  }
+
+  try {
+    if (asset.endsWith('.zip')) {
+      execFileSync('powershell', [
+        '-NoProfile',
+        '-Command',
+        `Expand-Archive -Force -Path "${archive}" -DestinationPath "${vendor}"`,
+      ]);
+    } else {
+      execFileSync('tar', ['-xzf', archive, '-C', vendor]);
+    }
+  } catch (err) {
+    fail('could not unpack the binary.', err.message);
+  }
+
+  fs.unlinkSync(archive);
+
+  // Prove it runs before declaring success. An archive that extracts but cannot
+  // execute — wrong arch, missing loader, Gatekeeper — is exactly the failure a
+  // postinstall must not pass along silently.
+  const bin = path.join(
+    vendor,
+    'llm-router',
+    process.platform === 'win32' ? 'llm-router.exe' : 'llm-router'
+  );
+  if (!fs.existsSync(bin)) fail('the archive did not contain the expected binary.', bin);
+  if (process.platform !== 'win32') fs.chmodSync(bin, 0o755);
+
+  try {
+    const out = execFileSync(bin, ['--version'], { encoding: 'utf8' }).trim();
+    console.log(`llm-routing: installed ${out}`);
+  } catch (err) {
+    const hint =
+      process.platform === 'darwin'
+        ? 'On macOS this is usually Gatekeeper. Until the build is notarised, ' +
+          'run:\n    xattr -dr com.apple.quarantine ' + path.dirname(bin)
+        : err.message;
+    fail('the binary was downloaded but will not run.', hint);
+  }
+
+  console.log('llm-routing: next step ->  llm-router install');
+}
+
+main().catch((err) => fail('unexpected error during install.', err.stack || err.message));

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "llm-routing",
+  "version": "13.0.8",
+  "description": "Stop hitting the limit on your Claude Pro or Max plan. Routes routine prompts to free and cheap models so your subscription quota is there when you need it. No API keys.",
+  "keywords": ["llm", "router", "claude", "claude-code", "codex", "cursor", "mcp", "cost-optimization", "quota", "ollama"],
+  "homepage": "https://github.com/ypollak2/llm-router#readme",
+  "bugs": { "url": "https://github.com/ypollak2/llm-router/issues" },
+  "repository": { "type": "git", "url": "git+https://github.com/ypollak2/llm-router.git" },
+  "license": "MIT",
+  "author": "ypollak2",
+  "bin": { "llm-router": "bin/llm-router.js" },
+  "files": ["bin/", "install.js", "README.md"],
+  "scripts": { "postinstall": "node install.js" },
+  "engines": { "node": ">=18" },
+  "os": ["darwin", "linux", "win32"],
+  "cpu": ["x64", "arm64"]
+}

--- a/packaging/llm-router.spec
+++ b/packaging/llm-router.spec
@@ -1,0 +1,95 @@
+# PyInstaller spec for the standalone llm-router binary (First Forty, task 35).
+#
+# WHY ONEDIR AND NOT ONEFILE
+#
+# A onefile build unpacks its whole archive to a temp directory on every
+# invocation. The dependency tree here is ~565 MB installed and ~313 MB
+# collected, and the hooks run on EVERY prompt and EVERY tool call — auto-route
+# on UserPromptSubmit, enforce-route on PreToolUse. Paying an unpack per
+# invocation would make the router slower than the premium model it is routing
+# away from.
+#
+# Measured on macOS, same machine, three runs each:
+#
+#     venv python      0.04 s
+#     onedir binary    0.08 s
+#
+# 40 ms of bootloader overhead is affordable on a per-prompt path. Onefile is
+# not, and no amount of tuning changes that: the cost is the unpack.
+#
+# WHY THE EXPLICIT COLLECTS
+#
+# cli.py imports litellm lazily, which is good design and defeats PyInstaller's
+# static analysis completely — the first build produced a working binary with
+# litellm entirely absent, discovered only by looking for its data file. litellm
+# additionally loads model_prices_and_context_window_backup.json (1.3 MB) at
+# runtime, so submodules alone are not enough; the data has to come too.
+#
+# tiktoken loads its encodings through a plugin namespace package
+# (tiktoken_ext) that is imported by string, so it needs the same treatment.
+
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_all, collect_submodules
+
+_ROOT = Path(SPECPATH).resolve().parent
+
+_datas, _binaries, _hidden = [], [], []
+for _pkg in ("litellm", "tiktoken", "tiktoken_ext"):
+    d, b, h = collect_all(_pkg)
+    _datas += d
+    _binaries += b
+    _hidden += h
+
+# The hook scripts and rules ship INSIDE the package and are copied out at
+# install time, so they must travel with the binary.
+_datas += [
+    (str(_ROOT / "src" / "llm_router" / "hooks"), "llm_router/hooks"),
+    (str(_ROOT / "src" / "llm_router" / "rules"), "llm_router/rules"),
+    (str(_ROOT / "src" / "llm_router" / "policies"), "llm_router/policies"),
+    (str(_ROOT / "src" / "llm_router" / "data"), "llm_router/data"),
+]
+_hidden += collect_submodules("llm_router")
+
+a = Analysis(
+    [str(_ROOT / "src" / "llm_router" / "cli.py")],
+    pathex=[str(_ROOT / "src")],
+    binaries=_binaries,
+    datas=_datas,
+    hiddenimports=_hidden,
+    hookspath=[],
+    runtime_hooks=[],
+    # Trimming what a CLI never needs. Each of these pulls in tens of MB.
+    excludes=["tkinter", "matplotlib", "PIL", "pytest", "IPython", "notebook"],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="llm-router",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,          # UPX corrupts signed macOS binaries and trips Gatekeeper
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,   # set by CI per-runner; universal2 needs fat deps
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    name="llm-router",
+)

--- a/src/llm_router/cli.py
+++ b/src/llm_router/cli.py
@@ -875,6 +875,38 @@ def main() -> None:
         print(f"llm_router v{__version__}")
         return
 
+    # `run-hook <path>` — execute a hook script in this interpreter.
+    #
+    # Hooks are registered as `<interpreter> <hook>.py`, which assumes a Python
+    # on the machine. A standalone binary has none: sys.executable IS the
+    # binary, and handing it a .py path would just be an unknown argument. This
+    # gives the frozen build a way to run its own hooks, so a user without
+    # Python still gets auto-routing rather than only the MCP tools.
+    #
+    # Deliberately not argparse'd or advertised in --help: it is an internal
+    # entry point that install_hooks writes into settings.json, not something to
+    # invoke by hand.
+    if args and args[0] == "run-hook":
+        if len(args) < 2:
+            print("llm-router run-hook: expected a hook path", file=sys.stderr)
+            sys.exit(2)
+        import runpy
+
+        hook_path = args[1]
+        # The hook reads sys.argv itself, so present it the argv it would have
+        # seen had it been launched directly.
+        sys.argv = [hook_path, *args[2:]]
+        try:
+            runpy.run_path(hook_path, run_name="__main__")
+        except SystemExit:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            # A hook that raises must not take the host's turn down with it —
+            # the same fail-open contract the hooks apply internally.
+            print(f"llm-router run-hook: {hook_path} failed: {exc}", file=sys.stderr)
+            sys.exit(0)
+        return
+
     if args and args[0] == "install":
         from llm_router.commands.install import cmd_install
         sys.exit(cmd_install(args[1:]))

--- a/src/llm_router/install_hooks.py
+++ b/src/llm_router/install_hooks.py
@@ -23,15 +23,30 @@ from pathlib import Path
 from llm_router.tool_surface import localize  # CHZ-SURF-01
 
 
-def _python_exe() -> str:
-    """Return the best Python interpreter path for use in hook command strings.
+def is_frozen() -> bool:
+    """True when running from a PyInstaller build rather than a Python install."""
+    return bool(getattr(sys, "frozen", False)) and hasattr(sys, "_MEIPASS")
 
-    Preference order:
-    1. The interpreter currently running this code (most reliable — same venv/pipx env).
+
+def _python_exe() -> str:
+    """Return the command prefix that will run a hook script.
+
+    Under a standalone binary this is NOT an interpreter. sys.executable is the
+    binary itself, and handing it a .py path would be an unknown argument — so
+    the prefix becomes `<binary> run-hook`, the internal entry point that
+    executes a hook in-process. That is what lets a machine with no Python
+    installed still get auto-routing rather than only the MCP tools.
+
+    Otherwise, preference order:
+    1. The interpreter currently running this code (same venv/pipx env).
     2. ``python3`` on PATH (Linux/macOS standard).
     3. ``python`` on PATH (Windows fallback).
     """
     import shutil as _shutil
+
+    if is_frozen():
+        return f"{sys.executable} run-hook"
+
     current = sys.executable
     if current and Path(current).exists():
         return current

--- a/tests/test_npm_wrapper.py
+++ b/tests/test_npm_wrapper.py
@@ -1,0 +1,142 @@
+"""The npm wrapper must stay in step with the binary workflow (task 37).
+
+npm is how this reaches Cursor users, Claude Desktop users, and the JS
+ecosystem — the audiences who will not install a Python toolchain to save money
+on tokens. The wrapper downloads the standalone binary built by
+.github/workflows/binary.yml, which means two files in different languages have
+to agree about asset names, versions and platforms.
+
+Nothing enforces that agreement at runtime: a mismatch surfaces as a 404 during
+someone else's `npm install`, which is the worst possible place to find out.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+NPM = REPO / "npm"
+INSTALL_JS = NPM / "install.js"
+WORKFLOW = REPO / ".github" / "workflows" / "binary.yml"
+
+
+def _package_json() -> dict:
+    return json.loads((NPM / "package.json").read_text())
+
+
+def test_npm_name_matches_the_adr():
+    """ADR 0001: one published name, `llm-routing`.
+
+    `llm-router` on npm is squatted, and npm rejects names too similar after
+    punctuation is stripped — `llm_router` and `llmrouter` both normalise to
+    `llmrouter` and would be refused at publish despite looking free.
+    """
+    assert _package_json()["name"] == "llm-routing"
+
+
+def test_npm_version_matches_pyproject():
+    """The wrapper builds its download URL from its own version.
+
+    A drift here points npm users at a release tag that does not exist.
+    """
+    import tomllib
+
+    py = tomllib.load((REPO / "pyproject.toml").open("rb"))["project"]["version"]
+    assert _package_json()["version"] == py, (
+        f"npm says {_package_json()['version']}, pyproject says {py} — the "
+        "postinstall would request a release tag that does not exist"
+    )
+
+
+def test_command_name_is_the_hyphenated_cli():
+    """ADR 0001 keeps the command hyphenated; the package name differs
+    deliberately, as with ripgrep/rg."""
+    assert list(_package_json()["bin"]) == ["llm-router"]
+
+
+def test_every_workflow_asset_is_downloadable():
+    """The two files must name the same artifacts.
+
+    This is the check that a mismatch would otherwise defer to a stranger's
+    `npm install` failing with a 404.
+    """
+    import yaml
+
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    assets = {m["asset"] for m in wf["jobs"]["build"]["strategy"]["matrix"]["include"]}
+
+    js = INSTALL_JS.read_text()
+    referenced = set(re.findall(r"(llm-router-[a-z0-9_-]+)\.(?:tar\.gz|zip)", js))
+
+    assert assets == referenced, (
+        f"asset names drifted.\n  built by CI: {sorted(assets)}\n"
+        f"  fetched by npm: {sorted(referenced)}"
+    )
+
+
+def test_platform_map_covers_what_package_json_claims():
+    """`os`/`cpu` in package.json tell npm which platforms may install.
+
+    Claiming a platform the postinstall cannot serve turns a clean
+    "unsupported" refusal into a failed install.
+    """
+    pkg = _package_json()
+    js = INSTALL_JS.read_text()
+    keys = set(re.findall(r"'(darwin|linux|win32)-(x64|arm64)'", js))
+    mapped_os = {k[0] for k in keys}
+
+    assert set(pkg["os"]) == mapped_os, (
+        f"package.json claims os={sorted(pkg['os'])} but install.js maps "
+        f"{sorted(mapped_os)}"
+    )
+
+
+def test_postinstall_verifies_the_binary_runs():
+    """Extracting is not installing.
+
+    A wrong-arch or Gatekeeper-quarantined binary extracts perfectly and then
+    fails on first use, mid-session. The postinstall must execute it.
+    """
+    js = INSTALL_JS.read_text()
+    assert "--version" in js, "postinstall never runs the binary it just installed"
+    assert "quarantine" in js, (
+        "no macOS Gatekeeper guidance; until the build is notarised (task 36) "
+        "this is the most likely failure a mac user hits"
+    )
+
+
+def test_failures_are_fatal_and_offer_a_way_out():
+    """A postinstall that swallows an error leaves a broken command on PATH."""
+    js = INSTALL_JS.read_text()
+    assert "process.exit(1)" in js
+    assert "pip install llm-routing" in js, (
+        "no fallback offered; a user whose platform has no binary is left stuck"
+    )
+
+
+def test_launcher_preserves_the_stdio_contract():
+    """llm-router is an MCP stdio server.
+
+    The host speaks to it over stdin/stdout, so the launcher must inherit those
+    streams rather than pipe them — any buffering or re-encoding corrupts the
+    protocol — and must propagate the child's exit code.
+    """
+    launcher = (NPM / "bin" / "llm-router.js").read_text()
+    assert "stdio: 'inherit'" in launcher, (
+        "the launcher pipes stdio, which corrupts the MCP stream"
+    )
+    assert "result.status" in launcher, "exit code is not propagated"
+
+
+def test_binary_is_not_vendored_into_the_package():
+    """Four platforms in one tarball would be >1 GB, three of them unusable."""
+    pkg = _package_json()
+    assert "vendor/" not in pkg.get("files", []), (
+        "the binary is vendored; the package should fetch only the matching one"
+    )
+    assert not (NPM / "vendor").exists() or not any((NPM / "vendor").iterdir()), (
+        "a built binary is sitting in npm/vendor and would be published"
+    )

--- a/tests/test_standalone_binary.py
+++ b/tests/test_standalone_binary.py
@@ -183,3 +183,46 @@ def test_binary_build_is_not_on_every_push():
     on_block = wf.split("on:")[1].split("permissions:")[0]
     assert "tags:" in on_block
     assert "pull_request" not in on_block
+
+
+# ── macOS signing (task 36) ───────────────────────────────────────────────────
+
+
+def test_signing_is_gated_on_secrets_being_present():
+    """A fork without Apple credentials must still get a working build.
+
+    Failing the job when secrets are absent would make every contributor's
+    branch red for a reason they cannot fix.
+    """
+    wf = WORKFLOW.read_text()
+    assert "notarytool" in wf, "no notarisation step"
+    assert 'if [ -z "${CERT_P12:-}" ]' in wf, (
+        "signing is not gated on the secret existing, so a fork's build fails"
+    )
+    assert "::warning::" in wf, (
+        "an unsigned build is produced silently; it must say so, because the "
+        "user-visible symptom is Gatekeeper quarantine much later"
+    )
+
+
+def test_signing_covers_bundled_libraries_not_just_the_launcher():
+    """A onedir loads .so/.dylib files at runtime.
+
+    An unsigned one fails notarisation for the whole archive, and the error
+    names the archive rather than the file, which makes it hard to chase.
+    """
+    wf = WORKFLOW.read_text()
+    assert '-name "*.so"' in wf and '-name "*.dylib"' in wf, (
+        "only the launcher is signed; bundled libraries will fail notarisation"
+    )
+    assert "--options runtime" in wf, "hardened runtime not enabled"
+
+
+def test_macos_packaging_preserves_signatures():
+    """GNU tar drops some extended attributes codesign writes, which
+    invalidates the signature on extraction."""
+    wf = WORKFLOW.read_text()
+    assert "ditto -c -k" in wf, (
+        "macOS artifacts are packaged with tar alone, which can strip the "
+        "metadata the signature depends on"
+    )

--- a/tests/test_standalone_binary.py
+++ b/tests/test_standalone_binary.py
@@ -1,0 +1,185 @@
+"""The standalone binary must be buildable, honest, and self-sufficient (task 35).
+
+Python 3.11+ is the prerequisite that keeps llm-router out of the hands of the
+audiences it most needs — Cursor users, Claude Desktop users, and the entire
+JS ecosystem, none of whom will install a Python toolchain to save money on
+tokens. The binary removes it.
+
+These tests do not build a binary; that takes ~40 s per platform and belongs in
+CI. They guard the decisions the build depends on, each of which was learned the
+expensive way during the spike.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SPEC = REPO / "packaging" / "llm-router.spec"
+WORKFLOW = REPO / ".github" / "workflows" / "binary.yml"
+
+
+def test_the_spec_exists_and_is_onedir():
+    """Onefile unpacks its archive on EVERY invocation.
+
+    The hooks run on every prompt and every tool call against a ~313 MB
+    collected tree. Measured: venv python 0.04 s, onedir binary 0.08 s. Onefile
+    pays an unpack per invocation and no tuning changes that, because the cost
+    IS the unpack.
+    """
+    assert SPEC.is_file(), "no PyInstaller spec"
+    src = SPEC.read_text()
+    assert "COLLECT(" in src, "not a onedir build — COLLECT is what makes it one"
+    assert "exclude_binaries=True" in src, (
+        "EXE does not exclude binaries, which makes this a onefile build"
+    )
+
+
+def test_litellm_is_explicitly_collected():
+    """The single most expensive lesson of the spike.
+
+    cli.py imports litellm lazily — good design, and it defeats PyInstaller's
+    static analysis completely. The first build produced a WORKING binary with
+    litellm entirely absent; it ran fine until something needed pricing data.
+    collect_all is required because the runtime also reads a 1.3 MB JSON.
+    """
+    src = SPEC.read_text()
+    assert "collect_all" in src
+    for pkg in ("litellm", "tiktoken"):
+        assert pkg in src, f"{pkg} is not collected; it will be silently missing"
+
+
+def test_hook_scripts_travel_with_the_binary():
+    """Hooks live inside the package and are copied out at install time.
+
+    Without them bundled, a binary can install its MCP server and no hooks at
+    all — the manual-tools-only degradation, silently.
+    """
+    src = SPEC.read_text()
+    assert "llm_router/hooks" in src, "hook scripts are not bundled"
+    assert "llm_router/rules" in src, "rules are not bundled"
+
+
+def test_upx_is_disabled():
+    """UPX corrupts signed macOS binaries and trips Gatekeeper.
+
+    A compression win that makes the artifact refuse to launch is not a win,
+    and task 36 (notarisation) depends on this staying off.
+    """
+    src = SPEC.read_text()
+    assert re.search(r"upx\s*=\s*False", src), "UPX is enabled somewhere in the spec"
+    assert not re.search(r"upx\s*=\s*True", src)
+
+
+# ── the frozen hook contract ──────────────────────────────────────────────────
+
+
+def test_installer_knows_it_is_frozen():
+    from llm_router import install_hooks as ih
+
+    assert hasattr(ih, "is_frozen")
+    # Not frozen under pytest, so the normal interpreter path must be taken.
+    assert ih.is_frozen() is False
+    assert "run-hook" not in ih._python_exe()
+
+
+def test_frozen_installs_route_hooks_through_run_hook(monkeypatch):
+    """sys.executable IS the binary under PyInstaller.
+
+    Writing `<binary> /path/to/hook.py` into settings.json would hand the CLI an
+    unknown argument on every prompt. The frozen build must register
+    `<binary> run-hook <path>` instead — which is the whole reason a machine
+    with no Python still gets auto-routing rather than only the MCP tools.
+    """
+    from llm_router import install_hooks as ih
+
+    monkeypatch.setattr(ih, "is_frozen", lambda: True)
+    monkeypatch.setattr(ih.sys, "executable", "/opt/llm-router/llm-router")
+
+    prefix = ih._python_exe()
+    assert prefix == "/opt/llm-router/llm-router run-hook", prefix
+
+
+def test_cli_exposes_run_hook(tmp_path):
+    """The entry point the frozen installer writes must actually exist."""
+    src = (REPO / "src" / "llm_router" / "cli.py").read_text()
+    assert '"run-hook"' in src, "cli has no run-hook entry point"
+    assert "runpy" in src, "run-hook does not execute the script"
+
+
+def test_run_hook_executes_a_script(tmp_path, capsys):
+    """End to end, in-process: the hook's own __main__ must run."""
+    import sys
+
+    from llm_router.cli import main
+
+    hook = tmp_path / "probe-hook.py"
+    hook.write_text("import sys\nprint('hook ran with', sys.argv[0])\n")
+
+    argv = sys.argv
+    try:
+        sys.argv = ["llm-router", "run-hook", str(hook)]
+        main()
+    finally:
+        sys.argv = argv
+
+    assert "hook ran with" in capsys.readouterr().out
+
+
+def test_run_hook_fails_open(tmp_path, capsys):
+    """A hook that raises must not take the host's turn down.
+
+    Same fail-open contract the hooks apply internally — a reporting or routing
+    hook is never worth breaking the session over.
+    """
+    import sys
+
+    from llm_router.cli import main
+
+    hook = tmp_path / "bad-hook.py"
+    hook.write_text("raise RuntimeError('boom')\n")
+
+    argv = sys.argv
+    try:
+        sys.argv = ["llm-router", "run-hook", str(hook)]
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 0, "a failing hook must not fail the turn"
+    finally:
+        sys.argv = argv
+
+
+# ── CI ────────────────────────────────────────────────────────────────────────
+
+
+def test_workflow_covers_every_platform_we_claim():
+    wf = WORKFLOW.read_text()
+    for target in ("macos-14", "macos-13", "ubuntu-latest", "windows-latest"):
+        assert target in wf, f"no binary is built for {target}"
+
+
+def test_workflow_smoke_tests_what_the_spike_got_wrong():
+    """A binary that builds and cannot run is worse than no binary: it ships.
+
+    The smoke test must check the two things that were silently absent from the
+    first working build.
+    """
+    wf = WORKFLOW.read_text()
+    assert "model_prices_and_context_window_backup.json" in wf, (
+        "CI does not verify litellm's data file, which was missing from a build "
+        "that otherwise passed --version and --help"
+    )
+    assert "run-hook" in wf, "CI never exercises the frozen hook path"
+    assert "--version" in wf
+
+
+def test_binary_build_is_not_on_every_push():
+    """~40 s per platform over a 565 MB tree, and nothing consumes an untagged
+    artifact."""
+    wf = WORKFLOW.read_text()
+    on_block = wf.split("on:")[1].split("permissions:")[0]
+    assert "tags:" in on_block
+    assert "pull_request" not in on_block


### PR DESCRIPTION
Tasks 35, 36 and 37. Python 3.11+ is the prerequisite that keeps llm-router away from the audiences most exposed to the quota problem — Cursor users, Claude Desktop users, the JS ecosystem — none of whom will install a Python toolchain to save money on tokens. This removes it.

## Onedir, not onefile — the load-bearing decision

A onefile build unpacks its whole archive on **every invocation**, and the hooks run on every prompt and every tool call against a ~313 MB collected tree.

Measured, same machine, three runs each:

| | startup |
|---|---|
| venv python | 0.04 s |
| onedir binary | **0.08 s** |
| onefile | pays an unpack, per invocation |

40 ms of bootloader overhead is affordable on a per-prompt path. Onefile is not, and no tuning changes it, because the cost *is* the unpack. A router slower than the model it routes away from is not a router.

## litellm was silently absent from the first build

`cli.py` imports litellm lazily — good design, and it defeats PyInstaller's static analysis completely. The first build produced a **working** binary with litellm entirely missing: it built, ran, and answered `--version` and `--help`. The only way to notice was to go looking for its data file.

It also loads a 1.3 MB pricing JSON at runtime, so collecting submodules alone would not have been enough. Both are collected explicitly now, and **CI asserts the data file exists** rather than trusting a green build to mean a working one.

## The frozen hook path

Hooks are registered as `<interpreter> <hook>.py` — the exact assumption this change removes. Under PyInstaller `sys.executable` **is** the binary, so the old code would have written `<binary> /path/to/hook.py` into `settings.json` and handed the CLI an unknown argument on every prompt.

`run-hook` executes a hook in-process, and `_python_exe()` returns `<binary> run-hook` when frozen. Without it the binary would install its MCP server and no hooks at all: manual-tools-only, degraded silently. It fails open — a hook that raises exits 0, matching the contract the hooks already apply internally.

## Signing (36) is gated on secrets existing

Without Apple credentials the job emits a `::warning::` naming the unsigned artifact and continues, so a fork gets a working unsigned build rather than a red X for a reason they cannot fix — and an unsigned artifact is never produced *silently*.

Signs every Mach-O, not just the launcher: a onedir loads its `.so`/`.dylib` at runtime, and an unsigned one fails notarisation for the whole archive with an error that names the archive rather than the file. macOS artifacts are packaged with `ditto` as well as `tar`, because GNU tar drops extended attributes `codesign` writes and invalidates the signature on extraction.

**Not verified end to end** — this needs Apple Developer credentials not available here. Required secrets are listed in the step. Until they are set, every macOS build is unsigned and says so.

## npm (37)

The binary is **not vendored**: four platforms in one tarball would exceed a gigabyte and hand every user the three they cannot run. `postinstall` fetches only the matching asset, and `os`/`cpu` make npm refuse cleanly on a platform we do not build for.

Every failure is fatal and loud, with `pip install llm-routing` offered as the way out — a postinstall that swallows an error leaves `llm-router` on PATH as a command that does not work, discovered mid-session. It also **executes** the binary before declaring success: extracting is not installing, and a wrong-arch or quarantined binary extracts perfectly then fails on first use.

The launcher inherits stdio rather than piping it. llm-router is an MCP **stdio** server; buffering or re-encoding in between corrupts the protocol.

## Tests

Two files in different languages now have to agree about asset names, versions and platforms, and nothing checks that at runtime — a mismatch surfaces as a 404 during a stranger's `npm install`. The parity tests catch it here instead. The asset-name test earned its place immediately by catching my own regex.

24 new tests. Full suite green; binary verified locally at 314 MB, 0.07–0.08 s startup, 32 hooks bundled, litellm data present, `run-hook` executing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4