### PR TITLE
Plugin: a marketplace install no longer needs pip first

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,11 @@
   "mcpServers": {
     "llm_router": {
       "type": "stdio",
-      "command": "llm-router",
-      "args": [],
+      "command": "npx",
+      "args": [
+        "-y",
+        "llm-routing"
+      ],
       "env": {}
     }
   }

--- a/scripts/build_plugin_bundle.py
+++ b/scripts/build_plugin_bundle.py
@@ -69,18 +69,31 @@ def _hooks_json(root_var: str) -> dict:
 
 
 def _mcp_json() -> dict:
-    """The MCP server entry, resolved through the plugin root rather than a venv.
+    """The MCP server entry a plugin-only install can actually run (task 38).
 
-    The previous manifests assumed a `llm-router` binary already on PATH from a
-    separate `pip install`. Declaring the module entry point keeps the plugin
-    self-describing; task 38 replaces this with the bundled binary.
+    `"command": "llm-router"` assumed a prior `pip install` had put the CLI on
+    PATH. Someone who installs from the marketplace has done no such thing, so
+    the plugin registered a server that could never start — the pip prerequisite
+    the marketplace channel exists to remove.
+
+    Vendoring the runtime into the plugin repo is not an option: the standalone
+    build is ~314 MB per platform. `npx -y` obtains it on demand instead, via
+    the npm wrapper, which downloads only the binary matching the host. That is
+    the same outcome as bundling from the user's point of view, without four
+    platform trees in git.
+
+    Node rather than Python deliberately. The audiences this channel targets —
+    Cursor, Claude Desktop, the JS ecosystem — have Node far more reliably than
+    a 3.11+ Python, and Node is what npx needs. A developer who already has
+    `llm-router` on PATH is unaffected: npx prefers a local binary of the same
+    name before fetching anything.
     """
     return {
         "mcpServers": {
             "llm_router": {
                 "type": "stdio",
-                "command": "llm-router",
-                "args": [],
+                "command": "npx",
+                "args": ["-y", "llm-routing"],
                 "env": {},
             }
         }

--- a/tests/test_first_forty_w1_plugin.py
+++ b/tests/test_first_forty_w1_plugin.py
@@ -266,3 +266,44 @@ def test_the_scanner_config_scopes_rather_than_disables():
         "all of src/ is excluded, which would hide a genuine leak in "
         "application code — the one finding worth keeping"
     )
+
+
+def test_plugin_mcp_command_works_without_a_prior_install():
+    """A marketplace install must not assume pip already ran (task 38).
+
+    `"command": "llm-router"` assumed the CLI was already on PATH from a
+    separate `pip install`. Someone installing from the marketplace has done no
+    such thing, so the plugin registered a server that could never start — the
+    exact prerequisite this channel exists to remove.
+    """
+    mcp = json.loads((REPO / ".mcp.json").read_text())
+    entry = mcp["mcpServers"]["llm_router"]
+
+    assert entry["command"] != "llm-router", (
+        "the plugin still assumes llm-router is on PATH, which it is not for "
+        "anyone who installed only the plugin"
+    )
+    assert entry["command"] == "npx", entry
+    assert entry["args"][:2] == ["-y", "llm-routing"], (
+        f"npx invocation is not the published package name: {entry['args']}"
+    )
+
+
+def test_plugin_does_not_vendor_the_binary():
+    """~314 MB per platform. Four of them in git is not a plugin.
+
+    Checks what git TRACKS, not what happens to be on disk — an untracked
+    scratch file is not a publishing problem, and the first version of this test
+    failed on one.
+    """
+    tracked = subprocess.run(
+        ["git", "ls-files"], capture_output=True, text=True, cwd=REPO
+    ).stdout.splitlines()
+
+    vendored = [
+        f
+        for f in tracked
+        if f.endswith((".tar.gz", ".zip"))
+        or f.startswith(("llm-router-macos", "llm-router-linux", "llm-router-windows"))
+    ]
+    assert not vendored, f"built artifacts are committed: {vendored}"


### PR DESCRIPTION
Task 38, unblocked by 35 and 37.

The plugin declared `"command": "llm-router"`, which assumed a prior `pip install` had put the CLI on PATH. **Someone installing from the marketplace has done no such thing**, so the plugin registered an MCP server that could never start. The plugin looked installed and did nothing — the exact prerequisite this channel exists to remove.

`npx -y llm-routing` obtains the runtime on demand through the npm wrapper, which downloads only the binary matching the host.

**Why not actually vendor it:** the standalone build is ~314 MB per platform. Four platform trees in git is not a plugin. From the user's side the outcome is identical to bundling.

**Why Node rather than Python:** the audiences this channel targets — Cursor, Claude Desktop, the JS ecosystem — have Node far more reliably than a 3.11+ Python, which is the whole reason task 35 exists. A developer who already has `llm-router` on PATH is unaffected: npx prefers a local binary of that name before fetching anything.

The vendoring test checks what git **tracks** rather than what happens to be on disk; its first version failed on an untracked scratch file, which is not a publishing problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4