### PR TITLE
Attach binaries to the release, not only the workflow run

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -178,6 +178,8 @@ jobs:
             fi
           fi
 
+      # Run artifacts: for inspecting a workflow_dispatch build. These expire and
+      # live at a URL nothing else references.
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.asset }}
@@ -186,3 +188,27 @@ jobs:
             ${{ matrix.asset }}.zip
           if-no-files-found: error
           retention-days: 14
+
+      # RELEASE assets: what the npm postinstall actually downloads.
+      #
+      # These are two different destinations and it is easy to ship only the
+      # first. upload-artifact attaches to the workflow RUN and expires;
+      # npm/install.js fetches
+      #   https://github.com/<repo>/releases/download/v<version>/<asset>
+      # which requires a release asset. Building perfect binaries into the run
+      # and never onto the release means every `npm install` 404s, and the
+      # failure lands on a stranger rather than in CI.
+      - name: Attach to the release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # --clobber so re-running a tag build replaces rather than fails.
+          gh release upload "${GITHUB_REF_NAME}" \
+            ${{ matrix.asset }}.tar.gz ${{ matrix.asset }}.zip \
+            --clobber --repo "${GITHUB_REPOSITORY}" 2>/dev/null || \
+          gh release upload "${GITHUB_REF_NAME}" \
+            ${{ matrix.asset }}.tar.gz \
+            --clobber --repo "${GITHUB_REPOSITORY}"

--- a/tests/test_npm_wrapper.py
+++ b/tests/test_npm_wrapper.py
@@ -140,3 +140,26 @@ def test_binary_is_not_vendored_into_the_package():
     assert not (NPM / "vendor").exists() or not any((NPM / "vendor").iterdir()), (
         "a built binary is sitting in npm/vendor and would be published"
     )
+
+
+def test_binaries_reach_the_url_npm_downloads_from():
+    """Building the artifact is not publishing it.
+
+    upload-artifact attaches to the workflow RUN and expires after 14 days.
+    install.js fetches from releases/download/v<version>/<asset>, which is a
+    RELEASE asset — a different destination entirely. A workflow that only does
+    the first builds perfect binaries that no `npm install` can ever reach, and
+    the 404 lands on a stranger rather than in CI.
+    """
+    wf = WORKFLOW.read_text()
+    js = INSTALL_JS.read_text()
+
+    assert "releases/download" in js, "install.js no longer uses release assets"
+    assert "gh release upload" in wf, (
+        "the workflow never attaches binaries to the release, so every "
+        "npm install would 404 on the URL install.js builds"
+    )
+    assert "startsWith(github.ref, 'refs/tags/v')" in wf, (
+        "release upload is not gated on a tag; a dispatch build would try to "
+        "upload to a release that does not exist"
+    )


### PR DESCRIPTION
Found while preparing to publish to npm — **before** publishing rather than after.

`binary.yml` used `actions/upload-artifact`, which attaches to the workflow **run** and expires in 14 days. `npm/install.js` downloads from

```
https://github.com/<repo>/releases/download/v<version>/<asset>
```

which is a **release asset** — a different destination entirely.

The workflow built correct binaries for four platforms and put them somewhere no `npm install` could ever reach. Every postinstall would have 404'd, and the failure would have landed on a stranger's machine rather than in CI.

**The parity test that was supposed to prevent this only compared asset names.** Names matching means nothing if the artifact never arrives at the URL. It now asserts the workflow uploads to the release, and that the upload is gated on a tag so a `workflow_dispatch` build does not try to upload to a release that does not exist.

Both destinations are kept: run artifacts for inspecting a dispatch build, release assets for what users download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4