### PR TITLE
Release 13.1.0 — the version that can ship the binary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,12 +7,12 @@
     {
       "name": "llm-router",
       "description": "Route text, image, video, and audio tasks to 20+ AI providers with smart routing, budget control, and multi-step orchestration",
-      "version": "13.0.8",
+      "version": "13.1.0",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"
       }
     }
   ],
-  "version": "13.0.8"
+  "version": "13.1.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.0.8",
+  "version": "13.1.0",
   "description": "Smart LLM routing with Claude subscription monitoring, complexity-first model selection, and 20+ AI providers",
   "author": {
     "name": "ypollak2",

--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Yali Pollak"
   },
-  "version": "13.0.8",
+  "version": "13.1.0",
   "plugins": [
     {
       "name": "llm-router",
       "description": "Route every Codex task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy.",
-      "version": "13.0.8",
+      "version": "13.1.0",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.0.8",
+  "version": "13.1.0",
   "description": "Route every Codex task to the cheapest capable model \u2014 Gemini Flash, Haiku, Ollama, Perplexity, and 20+ providers. Tracks cross-session savings, enforces routing policy.",
   "author": {
     "name": "ypollak2",

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Yali Pollak"
   },
-  "version": "13.0.8",
+  "version": "13.1.0",
   "plugins": [
     {
       "name": "llm-router",
       "description": "Route every Droid task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy, and sends weekly Slack digests.",
-      "version": "13.0.8",
+      "version": "13.1.0",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.0.8",
+  "version": "13.1.0",
   "description": "Route every Droid task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy, and sends weekly Slack digests.",
   "author": {
     "name": "ypollak2",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,17 +1,50 @@
 {
   "name": "llm-routing",
-  "version": "13.0.8",
+  "version": "13.1.0",
   "description": "Stop hitting the limit on your Claude Pro or Max plan. Routes routine prompts to free and cheap models so your subscription quota is there when you need it. No API keys.",
-  "keywords": ["llm", "router", "claude", "claude-code", "codex", "cursor", "mcp", "cost-optimization", "quota", "ollama"],
+  "keywords": [
+    "llm",
+    "router",
+    "claude",
+    "claude-code",
+    "codex",
+    "cursor",
+    "mcp",
+    "cost-optimization",
+    "quota",
+    "ollama"
+  ],
   "homepage": "https://github.com/ypollak2/llm-router#readme",
-  "bugs": { "url": "https://github.com/ypollak2/llm-router/issues" },
-  "repository": { "type": "git", "url": "git+https://github.com/ypollak2/llm-router.git" },
+  "bugs": {
+    "url": "https://github.com/ypollak2/llm-router/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ypollak2/llm-router.git"
+  },
   "license": "MIT",
   "author": "ypollak2",
-  "bin": { "llm-router": "bin/llm-router.js" },
-  "files": ["bin/", "install.js", "README.md"],
-  "scripts": { "postinstall": "node install.js" },
-  "engines": { "node": ">=18" },
-  "os": ["darwin", "linux", "win32"],
-  "cpu": ["x64", "arm64"]
+  "bin": {
+    "llm-router": "bin/llm-router.js"
+  },
+  "files": [
+    "bin/",
+    "install.js",
+    "README.md"
+  ],
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-routing"
-version = "13.0.8"
+version = "13.1.0"
 description = "Multi-LLM router MCP server — smart complexity routing, budget-aware model selection, 20+ providers (Claude, OpenAI, Gemini, Ollama, etc.)"
 readme = "README.md"
 license = "MIT"

--- a/scripts/ci/verify-version-sync.py
+++ b/scripts/ci/verify-version-sync.py
@@ -9,6 +9,7 @@ This script ensures that version is in sync across:
 - .codex-plugin/marketplace.json
 - .factory-plugin/plugin.json
 - .factory-plugin/marketplace.json
+- npm/package.json
 
 Fails with exit code 1 if versions don't match, enabling use in CI.
 """
@@ -69,6 +70,23 @@ def read_marketplace_json_versions(project_root: Path, plugin_dir: str) -> tuple
     return plugin_version, marketplace_version
 
 
+def read_npm_version(project_root: Path) -> str:
+    """Read version from npm/package.json.
+
+    The npm postinstall builds its download URL from this version:
+
+        https://github.com/<repo>/releases/download/v<version>/<asset>
+
+    So a drift here does not fail a build — it points every `npm install` at a
+    release tag that does not exist, and the 404 lands on a stranger.
+    """
+    package_path = project_root / "npm" / "package.json"
+    if not package_path.exists():
+        raise FileNotFoundError(f"package.json not found at {package_path}")
+    with package_path.open() as handle:
+        return json.load(handle)["version"]
+
+
 def main():
     """Verify all versions are in sync."""
     project_root = Path(__file__).parent.parent.parent
@@ -85,6 +103,8 @@ def main():
             versions[f"{plugin_dir}/plugin.json"] = plugin_version
             versions[f"{plugin_dir}/marketplace.json (plugin)"] = marketplace_plugin_version
             versions[f"{plugin_dir}/marketplace.json (root)"] = marketplace_version
+
+        versions["npm/package.json"] = read_npm_version(project_root)
 
         print("📋 Version Sync Check")
         print("=" * 50)


### PR DESCRIPTION
Prepares the release that the npm publish depends on.

## Why 13.0.8 cannot be the npm release

It was tagged **before** the binary workflow existed, so its GitHub release has **zero assets**. `npm/install.js` builds its download URL from the package version:

```
https://github.com/<repo>/releases/download/v<version>/<asset>
```

Publishing against 13.0.8 would 404 for every user on every platform. Tagging 13.1.0 runs the binary workflow, which now attaches all four platform archives to the release (#105) — so the URL exists before anything points at it.

Minor rather than patch: this adds two distribution channels and the frozen hook path. Nothing is removed, and nothing changes for an existing pip user.

## verify-version-sync now knows npm exists

It checked `pyproject.toml` and the three plugin manifests and had no idea `npm/package.json` was there. A release could have bumped everything else and left npm pointing at a tag that was never created — a failure that does not break a build, only a stranger's install.

Ten locations, all in sync at 13.1.0, and the runtime reports it from the source tree.

## After this merges

1. `npm login` — needs your 2FA
2. `git tag v13.1.0 && git push origin v13.1.0` — triggers the binary build and attaches the assets
3. `gh release view v13.1.0 --json assets --jq '.assets[].name'` — confirm all four landed
4. `cd npm && npm publish --tag next` — then install it yourself once on a clean machine before promoting to `latest`

Step 2 must complete before step 4, or the postinstall 404s regardless of anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4