### PR TITLE
Create the release if a tag push did not

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -205,6 +205,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # A TAG IS NOT A RELEASE. `gh release upload` needs a release object,
+          # and pushing a tag does not create one — the first real tag build hit
+          # exactly this and would have failed at the upload step with every
+          # binary already built. Create it if absent, then upload.
+          gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1 || \
+            gh release create "${GITHUB_REF_NAME}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${GITHUB_REF_NAME}" \
+              --generate-notes
+
           # --clobber so re-running a tag build replaces rather than fails.
           gh release upload "${GITHUB_REF_NAME}" \
             ${{ matrix.asset }}.tar.gz ${{ matrix.asset }}.zip \

--- a/tests/test_npm_wrapper.py
+++ b/tests/test_npm_wrapper.py
@@ -163,3 +163,21 @@ def test_binaries_reach_the_url_npm_downloads_from():
         "release upload is not gated on a tag; a dispatch build would try to "
         "upload to a release that does not exist"
     )
+
+
+def test_release_upload_does_not_assume_a_release_exists():
+    """A tag is not a release.
+
+    `gh release upload` requires a release object, and pushing a tag does not
+    create one. The first real tag build hit exactly this: every binary built
+    correctly and the upload step would have failed with nothing to attach to.
+    """
+    wf = WORKFLOW.read_text()
+    assert "gh release create" in wf, (
+        "the workflow uploads to a release it never creates; a plain tag push "
+        "leaves nothing to upload to"
+    )
+    assert "gh release view" in wf, (
+        "no existence check before creating — a re-run would fail on the "
+        "already-created release"
+    )


### PR DESCRIPTION
**A tag is not a release.** `gh release upload` requires a release object, and pushing a tag does not create one.

Caught on the first real tag build. `v13.1.0` was pushed, the binary jobs ran, and no release existed for the tag — so every binary built correctly and the **"Attach to the release" step failed on all three completed platforms**, at the last step, after ~40s of work each, on the one run that mattered.

The workflow now checks for the release and creates it with generated notes if absent, before uploading. The existence check matters as much as the create: a re-run of the same tag would otherwise fail on the release it made the first time.

A test asserts both, so this cannot regress into the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4