### PR TITLE
Release 13.1.1 — the tag that can attach binaries

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,12 +7,12 @@
     {
       "name": "llm-router",
       "description": "Route text, image, video, and audio tasks to 20+ AI providers with smart routing, budget control, and multi-step orchestration",
-      "version": "13.1.0",
+      "version": "13.1.1",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"
       }
     }
   ],
-  "version": "13.1.0"
+  "version": "13.1.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "description": "Smart LLM routing with Claude subscription monitoring, complexity-first model selection, and 20+ AI providers",
   "author": {
     "name": "ypollak2",

--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Yali Pollak"
   },
-  "version": "13.1.0",
+  "version": "13.1.1",
   "plugins": [
     {
       "name": "llm-router",
       "description": "Route every Codex task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy.",
-      "version": "13.1.0",
+      "version": "13.1.1",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "description": "Route every Codex task to the cheapest capable model \u2014 Gemini Flash, Haiku, Ollama, Perplexity, and 20+ providers. Tracks cross-session savings, enforces routing policy.",
   "author": {
     "name": "ypollak2",

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Yali Pollak"
   },
-  "version": "13.1.0",
+  "version": "13.1.1",
   "plugins": [
     {
       "name": "llm-router",
       "description": "Route every Droid task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy, and sends weekly Slack digests.",
-      "version": "13.1.0",
+      "version": "13.1.1",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "description": "Route every Droid task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy, and sends weekly Slack digests.",
   "author": {
     "name": "ypollak2",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-routing",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "description": "Stop hitting the limit on your Claude Pro or Max plan. Routes routine prompts to free and cheap models so your subscription quota is there when you need it. No API keys.",
   "keywords": [
     "llm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-routing"
-version = "13.1.0"
+version = "13.1.1"
 description = "Multi-LLM router MCP server — smart complexity routing, budget-aware model selection, 20+ providers (Claude, OpenAI, Gemini, Ollama, etc.)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
`v13.1.0`'s binary jobs all failed at **"Attach to the release"**: the tag was pushed, no release object existed, and `gh release upload` needs one. Every binary built correctly and had nowhere to go. Creating the release by hand came too late for those jobs, and the macOS Intel runner then sat queued for over an hour, so the run could not be re-run either.

#107 fixes the workflow to create the release if absent. This is the version that exercises it.

**Patch, not minor** — nothing changes for a user. 13.1.0 shipped to PyPI and is fine; it simply has no binaries attached, which makes it unusable as the npm release, because `npm/install.js` builds its download URL from the package version.

The npm package remains unpublished, correctly. Publishing against a release with no assets would 404 for every user on every platform — which is precisely what the failed 2FA prompt prevented.

## After merge

```bash
git tag v13.1.1 && git push origin v13.1.1
gh release view v13.1.1 --json assets --jq '.assets[].name'   # wait for all four
cd npm && npm publish --tag next --otp=<6-digit>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4