### PR TITLE
The release job needs contents: write

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -19,6 +19,8 @@ on:
         type: boolean
         default: true
 
+# Least privilege at the workflow level; the one job that needs to write
+# escalates for itself below.
 permissions:
   contents: read
 
@@ -26,6 +28,12 @@ jobs:
   build:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    # Creating a release and uploading assets both require contents: write.
+    # The workflow-level `contents: read` made `gh release create` and
+    # `gh release upload` fail on every tag build — after every binary had been
+    # built, at the last step. Neither v13.1.0 nor v13.1.1 could attach a thing.
+    permissions:
+      contents: write
     strategy:
       fail-fast: false        # one platform failing must not hide the others
       matrix:

--- a/tests/test_npm_wrapper.py
+++ b/tests/test_npm_wrapper.py
@@ -181,3 +181,26 @@ def test_release_upload_does_not_assume_a_release_exists():
         "no existence check before creating — a re-run would fail on the "
         "already-created release"
     )
+
+
+def test_the_release_job_can_actually_write():
+    """Creating a release and uploading assets need contents: write.
+
+    The workflow declared `contents: read` and nothing overrode it, so
+    `gh release create` and `gh release upload` failed on every tag build —
+    after all four binaries had been built, at the very last step. Two tags,
+    v13.1.0 and v13.1.1, produced correct binaries and attached none of them.
+
+    A permission that is wrong fails at the end of the job, not the start,
+    which is the most expensive place for it to be wrong.
+    """
+    import yaml
+
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    job_perms = wf["jobs"]["build"].get("permissions", {})
+    assert job_perms.get("contents") == "write", (
+        "the build job cannot write releases, so no asset can ever attach; "
+        f"got {job_perms}"
+    )
+    # Still least-privilege at the top: only the job that needs it escalates.
+    assert wf["permissions"]["contents"] == "read"


### PR DESCRIPTION
**Two tags produced four correct binaries each and attached none of them.**

The workflow declared `permissions: contents: read` and nothing overrode it, so `gh release create` and `gh release upload` both failed on every tag build. The #107 create-if-missing fix could not work either — it needed the same permission it did not have.

`v13.1.0` and `v13.1.1` both built cleanly and failed at the last step, which is the most expensive place for a permission to be wrong: ~40s of PyInstaller per platform, four platforms, then nothing to show for it.

The build job now escalates to `contents: write` for itself. The workflow default stays `read`, so nothing else inherits it.

Guarded by a test that reads the **parsed YAML** rather than grepping — both previous release bugs looked fine in the file and only failed in the runner.

## After merge

```bash
git tag v13.1.2 && git push origin v13.1.2
gh release view v13.1.2 --json assets --jq '.assets[].name'   # expect four
cd npm && npm publish --tag next --otp=<6-digit>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4