### PR TITLE
Release 13.1.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,12 +7,12 @@
     {
       "name": "llm-router",
       "description": "Route text, image, video, and audio tasks to 20+ AI providers with smart routing, budget control, and multi-step orchestration",
-      "version": "13.1.2",
+      "version": "13.1.3",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"
       }
     }
   ],
-  "version": "13.1.2"
+  "version": "13.1.3"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.1.2",
+  "version": "13.1.3",
   "description": "Smart LLM routing with Claude subscription monitoring, complexity-first model selection, and 20+ AI providers",
   "author": {
     "name": "ypollak2",

--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Yali Pollak"
   },
-  "version": "13.1.2",
+  "version": "13.1.3",
   "plugins": [
     {
       "name": "llm-router",
       "description": "Route every Codex task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy.",
-      "version": "13.1.2",
+      "version": "13.1.3",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.1.2",
+  "version": "13.1.3",
   "description": "Route every Codex task to the cheapest capable model \u2014 Gemini Flash, Haiku, Ollama, Perplexity, and 20+ providers. Tracks cross-session savings, enforces routing policy.",
   "author": {
     "name": "ypollak2",

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Yali Pollak"
   },
-  "version": "13.1.2",
+  "version": "13.1.3",
   "plugins": [
     {
       "name": "llm-router",
       "description": "Route every Droid task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy, and sends weekly Slack digests.",
-      "version": "13.1.2",
+      "version": "13.1.3",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.1.2",
+  "version": "13.1.3",
   "description": "Route every Droid task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy, and sends weekly Slack digests.",
   "author": {
     "name": "ypollak2",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-routing",
-  "version": "13.1.2",
+  "version": "13.1.3",
   "description": "Stop hitting the limit on your Claude Pro or Max plan. Routes routine prompts to free and cheap models so your subscription quota is there when you need it. No API keys.",
   "keywords": [
     "llm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-routing"
-version = "13.1.2"
+version = "13.1.3"
 description = "Multi-LLM router MCP server — smart complexity routing, budget-aware model selection, 20+ providers (Claude, OpenAI, Gemini, Ollama, etc.)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Fourth tag for one release. Three bugs in the same workflow step, each an assumption that held on the platform in front of me:

| tag | assumption | reality |
|---|---|---|
| `v13.1.0` | a tag is a release | it is not |
| `v13.1.1` | the token can write | `contents: read` |
| `v13.1.2` | every platform makes a `.tar.gz` | Windows makes a `.zip` |

All fixed (#107, #109, #111). `v13.1.2` proved the first two — it attached Linux and macOS-arm64 for the first time and failed only on the third.

The empty `v13.1.0` and partial `v13.1.2` GitHub releases are deleted; their tags and PyPI publishes are untouched. **A partial release is worse than none**: three of four assets make it look finished, and a Windows user's install would 404 against a package that appears published.

## After merge

```bash
git tag v13.1.3 && git push origin v13.1.3
gh release view v13.1.3 --json assets --jq '.assets[].name'   # expect four
cd npm && npm publish --tag next --otp=<6-digit>
```

Note: macOS Intel (`macos-13`) runners have been queueing for hours. If it stalls again the other three still attach, and `install.js` fails cleanly on `darwin-x64` with a "no binary published" message rather than installing something broken — your call whether to publish on three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4