### PR TITLE
Release 13.1.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,12 +7,12 @@
     {
       "name": "llm-router",
       "description": "Route text, image, video, and audio tasks to 20+ AI providers with smart routing, budget control, and multi-step orchestration",
-      "version": "13.1.3",
+      "version": "13.1.4",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"
       }
     }
   ],
-  "version": "13.1.3"
+  "version": "13.1.4"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.1.3",
+  "version": "13.1.4",
   "description": "Smart LLM routing with Claude subscription monitoring, complexity-first model selection, and 20+ AI providers",
   "author": {
     "name": "ypollak2",

--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Yali Pollak"
   },
-  "version": "13.1.3",
+  "version": "13.1.4",
   "plugins": [
     {
       "name": "llm-router",
       "description": "Route every Codex task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy.",
-      "version": "13.1.3",
+      "version": "13.1.4",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.1.3",
+  "version": "13.1.4",
   "description": "Route every Codex task to the cheapest capable model \u2014 Gemini Flash, Haiku, Ollama, Perplexity, and 20+ providers. Tracks cross-session savings, enforces routing policy.",
   "author": {
     "name": "ypollak2",

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Yali Pollak"
   },
-  "version": "13.1.3",
+  "version": "13.1.4",
   "plugins": [
     {
       "name": "llm-router",
       "description": "Route every Droid task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy, and sends weekly Slack digests.",
-      "version": "13.1.3",
+      "version": "13.1.4",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.1.3",
+  "version": "13.1.4",
   "description": "Route every Droid task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy, and sends weekly Slack digests.",
   "author": {
     "name": "ypollak2",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-routing",
-  "version": "13.1.3",
+  "version": "13.1.4",
   "description": "Stop hitting the limit on your Claude Pro or Max plan. Routes routine prompts to free and cheap models so your subscription quota is there when you need it. No API keys.",
   "keywords": [
     "llm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-routing"
-version = "13.1.3"
+version = "13.1.4"
 description = "Multi-LLM router MCP server — smart complexity routing, budget-aware model selection, 20+ providers (Claude, OpenAI, Gemini, Ollama, etc.)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
The first tag cut with evidence rather than confidence.

## Four bugs preceded it, all in one workflow step

| tag | assumption | reality |
|---|---|---|
| `v13.1.0` | a tag is a release | it is not |
| `v13.1.1` | the token can write | `contents: read` |
| `v13.1.2` | every platform makes a `.tar.gz` | Windows makes a `.zip` |
| `v13.1.3` | `nullglob` drops missing files | only ones containing wildcards — Linux regressed after working |

Every one was reasoned about instead of run.

## What is different

A `workflow_dispatch` run on main built and packaged **green on all three available platforms, Windows included for the first time**:

```
llm-router-windows-x86_64   83 MB
llm-router-linux-x86_64     96 MB
llm-router-macos-arm64     160 MB
```

And the artifact-selection logic is now covered by a test that **executes** it against each platform's real file layout rather than matching text.

The dispatch could not exercise the upload itself — that step is gated on a tag ref and shows as `skipped` — so the two checks are complementary: CI proves build and packaging, the unit test proves selection.

## Known gap

`macos-13` has been queued for hours on every run today. If it does not complete, three of four assets attach, and `install.js` fails cleanly on `darwin-x64` with the `pip install llm-routing` fallback rather than installing something broken.

## After merge

```bash
git tag v13.1.4 && git push origin v13.1.4
gh release view v13.1.4 --json assets --jq '.assets[].name'
cd npm && npm publish --tag next --otp=<6-digit>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4