### PR TITLE
Publish npm from the release, and ship a README

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -247,3 +247,77 @@ jobs:
           # --clobber so re-running a tag build replaces rather than fails.
           gh release upload "${GITHUB_REF_NAME}" "${artifacts[@]}" \
             --clobber --repo "${GITHUB_REPOSITORY}"
+
+  # ── npm, gated on the binaries actually existing ────────────────────────
+  #
+  # This job exists because of what happened on 13.1.4: the package was
+  # published by hand before any release asset existed, so every install 404'd
+  # on every platform — and npm can never republish a version, only deprecate
+  # it. The recovery was to rush the tag through and hope nobody installed in
+  # the window.
+  #
+  # Ordering is the whole point. `needs: build` means npm cannot publish until
+  # every binary job has succeeded, so the sequence that has to hold is
+  # enforced by the graph rather than by remembering it.
+  publish-npm:
+    name: Publish to npm
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      # The version in package.json is what install.js turns into a download
+      # URL. Publishing a version whose tag has no assets is the exact failure
+      # this job exists to prevent, so verify before publishing rather than
+      # after.
+      - name: Verify every asset the postinstall can request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./npm/package.json').version")"
+          tag="${GITHUB_REF_NAME}"
+          if [ "v$version" != "$tag" ]; then
+            echo "npm/package.json is $version but the tag is $tag" >&2
+            exit 1
+          fi
+
+          published=$(gh release view "$tag" --repo "${GITHUB_REPOSITORY}" \
+            --json assets --jq '[.assets[].name]|join(" ")')
+          echo "assets on $tag: $published"
+
+          # Every target install.js can select must be downloadable. A platform
+          # with no asset is a 404 for that user, and they cannot be told to
+          # wait for a later publish of the same version.
+          missing=0
+          for a in $(grep -oE "llm-router-[a-z0-9_-]+\.(tar\.gz|zip)" npm/install.js | sort -u); do
+            case " $published " in
+              *" $a "*) echo "  ok      $a" ;;
+              *)        echo "  MISSING $a"; missing=1 ;;
+            esac
+          done
+          [ "$missing" -eq 0 ] || {
+            echo "refusing to publish: install.js can request assets that do not exist" >&2
+            exit 1
+          }
+
+      - name: Publish
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::warning::NPM_TOKEN is not configured — skipping the npm publish."
+            exit 0
+          fi
+          npm publish --provenance --access public

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,83 @@
+# llm-routing
+
+**Stop hitting the limit on your Claude Pro or Max plan.**
+
+Routes the routine prompts — "what does this error mean", "reformat this JSON",
+"is the service up" — to free and cheap models, so your subscription quota is
+still there when you need it at 4pm. Same workflow, same commands. The model
+choice changes underneath.
+
+```bash
+npx -y llm-routing install
+```
+
+No API keys required. No hosted proxy. No account.
+
+---
+
+## Why this package is 3 kB
+
+It contains three files, and that is deliberate.
+
+`llm-router` is a Python program shipped as a **standalone binary** — roughly
+300 MB per platform, because it carries its own interpreter and a large provider
+library. Vendoring all four platforms into one npm tarball would exceed a
+gigabyte and hand every user the three they cannot run.
+
+So `postinstall` downloads the one binary that matches your platform from the
+matching [GitHub release](https://github.com/ypollak2/llm-router/releases), and
+`bin/llm-router.js` hands off to it. That is the whole package.
+
+If the download fails, the install **fails loudly** rather than leaving a broken
+`llm-router` on your PATH to be discovered mid-session.
+
+## Why a proxy cannot do this
+
+Every other router in this category is a proxy: you point your agent at a local
+endpoint and it forwards requests using *your API keys*. That design has a hard
+limit — **a proxy cannot intercept a session authenticated by a subscription,
+because there is no key to forward.**
+
+If you pay per token, a proxy serves you well and there are good ones. If you pay
+a flat monthly fee and the thing you run out of is *quota*, this is the gap it
+fills.
+
+## Supported platforms
+
+| Platform | Status |
+|---|---|
+| macOS arm64 | supported |
+| macOS x86_64 | supported |
+| Linux x86_64 | supported |
+| Windows x86_64 | supported |
+
+On an unsupported platform the install refuses cleanly and points you at
+`pip install llm-routing`, which works anywhere Python 3.11+ does.
+
+### macOS: Gatekeeper
+
+The binaries are not yet notarised, so macOS quarantines them on first run. If
+`llm-router` will not start:
+
+```bash
+xattr -dr com.apple.quarantine "$(dirname "$(readlink -f "$(which llm-router)")")"
+```
+
+## After installing
+
+```bash
+llm-router install     # wire up your host (Claude Code by default)
+llm-router doctor      # verify everything is connected
+llm-router status      # today's savings and quota
+```
+
+## Links
+
+- **Source, docs and issues** — https://github.com/ypollak2/llm-router
+- **PyPI** (`pip install llm-routing`) — https://pypi.org/project/llm-routing/
+- **Benchmark write-up**, including what did *not* work —
+  [docs/ROUTERARENA.md](https://github.com/ypollak2/llm-router/blob/main/docs/ROUTERARENA.md)
+- **Host support matrix**, including what each host genuinely cannot do —
+  [guide/HOST_SUPPORT_MATRIX.md](https://github.com/ypollak2/llm-router/blob/main/guide/HOST_SUPPORT_MATRIX.md)
+
+MIT licensed.

--- a/tests/test_npm_wrapper.py
+++ b/tests/test_npm_wrapper.py
@@ -263,3 +263,79 @@ def test_upload_selection_is_correct_for_each_platform():
                 f"{platform} builds {built} but the upload selected {out} "
                 f"artifacts, expected {expected}"
             )
+
+
+# ── npm publishing belongs to the release, not to a terminal ──────────────────
+
+
+def test_npm_publish_is_part_of_the_release_workflow():
+    """13.1.4 was published by hand before any asset existed.
+
+    Every install 404'd on every platform, and npm can never republish a
+    version — only deprecate it. The recovery was to rush the tag through and
+    hope nobody installed in the window.
+    """
+    import yaml
+
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    assert "publish-npm" in wf["jobs"], "npm publishing is still a manual step"
+
+
+def test_npm_publish_cannot_run_before_the_binaries():
+    """Ordering enforced by the graph, not by remembering it."""
+    import yaml
+
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    job = wf["jobs"]["publish-npm"]
+    assert job["needs"] == "build" or "build" in job["needs"], (
+        "publish-npm does not depend on the binary build, so it could publish "
+        "before a single asset exists — exactly what happened with 13.1.4"
+    )
+    assert "refs/tags/v" in job["if"], "npm would publish on a non-tag run"
+
+
+def test_npm_publish_verifies_every_asset_it_could_request():
+    """A platform with no asset is a 404 for that user, and they cannot be told
+    to wait for a later publish of the same version."""
+    wf = WORKFLOW.read_text()
+    step = wf.split("Verify every asset")[1].split("- name: Publish")[0]
+
+    assert "gh release view" in step, "the assets on the release are never read"
+    assert "install.js" in step, (
+        "the check does not derive its list from install.js, so a target added "
+        "there could be published without a binary"
+    )
+    assert "exit 1" in step, "a missing asset does not stop the publish"
+
+
+def test_npm_publish_checks_version_against_the_tag():
+    """install.js turns package.json's version into the download URL.
+
+    Publishing 13.1.4 from a v13.1.3 tag points every install at the wrong
+    release.
+    """
+    wf = WORKFLOW.read_text()
+    step = wf.split("Verify every asset")[1].split("- name: Publish")[0]
+    assert "GITHUB_REF_NAME" in step and "package.json" in step
+
+
+def test_the_package_ships_a_readme():
+    """package.json listed README.md in `files` and the file did not exist.
+
+    13.1.4 published with nothing for the npm page to render: a visitor saw
+    three tiny files, no explanation, and no reason to believe a 3 kB package
+    does anything. The package was correct and looked like a mistake, which for
+    a first impression is the same thing.
+    """
+    readme = NPM / "README.md"
+    assert readme.is_file(), "npm/README.md is missing; the npm page renders nothing"
+    assert "README.md" in _package_json()["files"], (
+        "README.md is not in `files`, so it will not be included in the tarball"
+    )
+
+    text = readme.read_text()
+    # The single question a visitor asks about a 3 kB package.
+    assert "3 kB" in text or "300 MB" in text, (
+        "the README does not explain why the package is tiny, which is the "
+        "first thing anyone looking at the code tab wonders"
+    )


### PR DESCRIPTION
Two problems with how 13.1.4 reached npm.

## It was published by hand, before any asset existed

The tag had not been pushed, the release did not exist, and **every install 404'd on every platform**. npm can never republish a version — only deprecate it — so the recovery was to rush the tag through and hope nobody installed in the window.

The package is fine now (`npx -y llm-routing@13.1.4 --version` → `llm_router v13.1.4`, all asset URLs 200), but that was luck rather than process.

`publish-npm` now runs from the release workflow with **`needs: build`**, so npm cannot publish until every binary job has succeeded. The ordering that has to hold is enforced by the graph instead of by remembering it.

Before publishing it also:
- re-reads the release and checks **every asset `install.js` could request** actually exists — deriving the list *from* `install.js`, so a target added there cannot ship without a binary
- asserts `package.json`'s version matches the tag — publishing 13.1.4 from a `v13.1.3` tag would point every install at the wrong release

Gated on `NPM_TOKEN`; without it the job warns and skips rather than failing a fork's build.

## It shipped without a README

`package.json` listed `README.md` in `files` and **the file did not exist**, so the npm page rendered nothing. A visitor saw three tiny files, no explanation, and no reason to believe a 3 kB package does anything.

The package was correct and looked like a mistake — which, for a first impression, is the same thing.

The README leads with the wedge and answers the question the code tab provokes: why 3 kB, and where the 300 MB actually comes from.

## Note

Neither fix can reach 13.1.4. npm versions are immutable; these apply from the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4