### PR TITLE
Skip the npm publish on an invalid token, not just an absent one

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -316,8 +316,32 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
+
           if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
             echo "::warning::NPM_TOKEN is not configured — skipping the npm publish."
             exit 0
           fi
+
+          # An EMPTY token and an INVALID one are different failures, and only
+          # the first was handled. An invalid token got as far as `npm publish`
+          # and died on a 401 halfway through a release, which reads like the
+          # publish broke rather than like the credential is wrong.
+          #
+          # Checked here because the two mistakes are easy to make and look
+          # identical from the outside:
+          #   - an npm OTP (six digits, ~30s lifetime) is not a token, and CI
+          #     cannot use one: it expires before the build reaches this step
+          #   - a token without "bypass 2FA" authenticates for reads and is
+          #     refused for publish, so whoami alone is not proof
+          if ! npm whoami --registry https://registry.npmjs.org/ >/dev/null 2>&1; then
+            echo "::warning::NPM_TOKEN did not authenticate (401) — skipping the npm publish."
+            echo "Generate a GRANULAR ACCESS TOKEN at npmjs.com with:"
+            echo "  packages    : llm-routing"
+            echo "  permissions : read and write"
+            echo "  2FA         : bypass enabled  (CI cannot answer an OTP prompt)"
+            echo "It starts with npm_ . A six-digit OTP is not a token."
+            exit 0
+          fi
+          echo "authenticated as: $(npm whoami --registry https://registry.npmjs.org/)"
+
           npm publish --provenance --access public

--- a/tests/test_npm_wrapper.py
+++ b/tests/test_npm_wrapper.py
@@ -339,3 +339,34 @@ def test_the_package_ships_a_readme():
         "the README does not explain why the package is tiny, which is the "
         "first thing anyone looking at the code tab wonders"
     )
+
+
+def test_an_invalid_token_skips_rather_than_fails_mid_release():
+    """An empty token and an invalid one are different failures.
+
+    Only the first was handled, so an invalid token reached `npm publish` and
+    died on a 401 halfway through a release — which reads like the publish
+    broke rather than like the credential is wrong.
+
+    Two mistakes make this likely and they look identical from outside: an npm
+    OTP is six digits with a ~30 second lifetime and cannot be used by CI at
+    all, and a token without 2FA bypass authenticates for reads while being
+    refused for publish.
+    """
+    wf = WORKFLOW.read_text()
+    step = wf.split("- name: Publish")[1]
+
+    assert "npm whoami" in step, (
+        "the token is never validated, so an invalid one fails at publish time "
+        "with a bare 401 instead of a clear message"
+    )
+    # Skip, not fail: a fork or a lapsed token must not break the release that
+    # already produced working binaries.
+    assert step.count("exit 0") >= 2, (
+        "an invalid token fails the job rather than skipping; the binaries are "
+        "already attached and a missing npm publish should not undo that"
+    )
+    assert "bypass" in step.lower(), (
+        "the failure message does not say what kind of token is needed, which "
+        "is the only thing the reader needs to know"
+    )


### PR DESCRIPTION
An **empty** token and an **invalid** one are different failures, and only the first was handled. An invalid token got as far as `npm publish` and died on a bare `401` halfway through a release — which reads like the publish broke rather than like the credential is wrong.

Two mistakes make this likely, and they look identical from outside the job:

- **An npm OTP is a six-digit code with a ~30 second lifetime.** It is not a token, and CI cannot use one at all — it expires long before a build reaches the publish step.
- **A token without "bypass 2FA" authenticates for reads and is refused for publish**, so a successful `whoami` is not by itself proof.

The job now calls `whoami` first and, on failure, warns with the exact token type required and skips.

**Skipping rather than failing is deliberate:** the binaries are already built and attached by that point, and a missing npm publish should not undo a release that otherwise succeeded.

Prompted by a real invalid credential, which cost nothing precisely because it was checked before a tag rather than during one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4