### PR TITLE
A scarce runner must not hold the release hostage

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -40,8 +40,6 @@ jobs:
         include:
           - os: macos-14      # arm64
             asset: llm-router-macos-arm64
-          - os: macos-13      # x86_64
-            asset: llm-router-macos-x86_64
           - os: ubuntu-latest
             asset: llm-router-linux-x86_64
           - os: windows-latest
@@ -248,6 +246,65 @@ jobs:
           gh release upload "${GITHUB_REF_NAME}" "${artifacts[@]}" \
             --clobber --repo "${GITHUB_REPOSITORY}"
 
+  # ── macOS Intel, deliberately outside the dependency chain ──────────────
+  #
+  # GitHub's macos-13 runners were scarce enough to queue for HOURS on every run
+  # across a full day and complete on none of them. It was originally a leg of
+  # the `build` matrix, which made it a hard block: `needs: build` waits for
+  # every leg to FINISH, and `always()` does not change that — it only decides
+  # whether the dependent runs once the wait is over. A permanently queued job
+  # therefore blocked the npm publish forever.
+  #
+  # So it builds on its own. When a runner frees up the asset is attached to the
+  # release exactly as before; until then a darwin-x64 user gets install.js's
+  # clean "no standalone binary is published for this platform" message and the
+  # pip fallback, rather than a broken install.
+  #
+  # continue-on-error so a failure here is visible without failing the release.
+  build-macos-x86:
+    name: macos-13 (best effort)
+    runs-on: macos-13
+    continue-on-error: true
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - name: Install project and PyInstaller
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install . pyinstaller
+      - name: Build
+        run: pyinstaller --noconfirm --clean packaging/llm-router.spec
+      - name: Smoke test
+        run: |
+          BIN=dist/llm-router/llm-router
+          "$BIN" --version
+          test -f dist/llm-router/_internal/litellm/model_prices_and_context_window_backup.json \
+            || { echo "litellm data file missing"; exit 1; }
+      - name: Package
+        run: |
+          cd dist
+          ditto -c -k --keepParent llm-router "../llm-router-macos-x86_64.zip"
+          tar -czf "../llm-router-macos-x86_64.tar.gz" llm-router
+      - name: Attach to the release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1 || \
+            gh release create "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" \
+              --title "${GITHUB_REF_NAME}" --generate-notes
+          artifacts=()
+          for f in "llm-router-macos-x86_64.tar.gz" "llm-router-macos-x86_64.zip"; do
+            [ -f "$f" ] && artifacts+=( "$f" )
+          done
+          gh release upload "${GITHUB_REF_NAME}" "${artifacts[@]}" \
+            --clobber --repo "${GITHUB_REPOSITORY}"
+
   # ── npm, gated on the binaries actually existing ────────────────────────
   #
   # This job exists because of what happened on 13.1.4: the package was
@@ -298,11 +355,23 @@ jobs:
           # Every target install.js can select must be downloadable. A platform
           # with no asset is a 404 for that user, and they cannot be told to
           # wait for a later publish of the same version.
+          # macOS Intel builds on a best-effort job outside this dependency
+          # chain, because its runners queue for hours. Missing it is tolerated
+          # and reported: install.js refuses cleanly on a platform with no asset
+          # and points at the pip fallback, so a darwin-x64 user gets an honest
+          # message rather than a broken install. Every OTHER platform is
+          # mandatory — those are the ones this release actually promises.
           missing=0
           for a in $(grep -oE "llm-router-[a-z0-9_-]+\.(tar\.gz|zip)" npm/install.js | sort -u); do
             case " $published " in
-              *" $a "*) echo "  ok      $a" ;;
-              *)        echo "  MISSING $a"; missing=1 ;;
+              *" $a "*) echo "  ok       $a" ;;
+              *)
+                case "$a" in
+                  *macos-x86_64*)
+                    echo "  optional $a (macOS Intel runner did not complete)" ;;
+                  *)
+                    echo "  MISSING  $a"; missing=1 ;;
+                esac ;;
             esac
           done
           [ "$missing" -eq 0 ] || {

--- a/tests/test_npm_wrapper.py
+++ b/tests/test_npm_wrapper.py
@@ -66,7 +66,14 @@ def test_every_workflow_asset_is_downloadable():
     import yaml
 
     wf = yaml.safe_load(WORKFLOW.read_text())
+    # Assets come from two places now: the gating matrix, and the best-effort
+    # macOS Intel job that sits outside the dependency chain. Reading only the
+    # matrix would report a false mismatch for a platform that IS built.
     assets = {m["asset"] for m in wf["jobs"]["build"]["strategy"]["matrix"]["include"]}
+    assets |= set(
+        re.findall(r"(llm-router-[a-z0-9_-]+)\.(?:tar\.gz|zip)",
+                   yaml.dump(wf["jobs"]["build-macos-x86"]))
+    )
 
     js = INSTALL_JS.read_text()
     referenced = set(re.findall(r"(llm-router-[a-z0-9_-]+)\.(?:tar\.gz|zip)", js))
@@ -369,4 +376,52 @@ def test_an_invalid_token_skips_rather_than_fails_mid_release():
     assert "bypass" in step.lower(), (
         "the failure message does not say what kind of token is needed, which "
         "is the only thing the reader needs to know"
+    )
+
+
+def test_a_scarce_runner_cannot_block_the_publish():
+    """macos-13 queued for hours on every run across a day and completed on none.
+
+    As a leg of the `build` matrix it was a hard block: `needs: build` waits for
+    every leg to FINISH, and `always()` does not change that — it only decides
+    whether the dependent runs once the wait is over. A permanently queued job
+    therefore blocked the npm publish forever.
+
+    It now builds outside the dependency chain and attaches when it lands.
+    """
+    import yaml
+
+    wf = yaml.safe_load(WORKFLOW.read_text())
+
+    matrix = wf["jobs"]["build"]["strategy"]["matrix"]["include"]
+    gating = {m["os"] for m in matrix}
+    assert "macos-13" not in gating, (
+        "macos-13 is back in the gating matrix, so a queued Intel runner blocks "
+        "the npm publish again"
+    )
+
+    assert "build-macos-x86" in wf["jobs"], "macOS Intel is no longer built at all"
+    assert wf["jobs"]["build-macos-x86"].get("continue-on-error") is True
+
+    needs = wf["jobs"]["publish-npm"]["needs"]
+    assert "build-macos-x86" not in str(needs), (
+        "publish-npm depends on the best-effort job, which reintroduces the block"
+    )
+
+
+def test_only_the_scarce_platform_is_optional():
+    """Relaxing the wait must not relax what the release promises.
+
+    Every platform except macOS Intel stays mandatory: publishing without a
+    Linux or Windows binary would 404 for those users, and npm cannot
+    republish a version to fix it.
+    """
+    wf = WORKFLOW.read_text()
+    step = wf.split("Verify every asset")[1].split("- name: Publish")[0]
+
+    assert "macos-x86_64" in step, "no platform is treated as optional"
+    assert "exit 1" in step, "a missing mandatory asset no longer stops the publish"
+    # The tolerated case must be narrow — a wildcard would excuse everything.
+    assert "*macos-x86_64*" in step, (
+        "the optional case is not scoped to macOS Intel specifically"
     )


### PR DESCRIPTION
GitHub's `macos-13` runners queued for **hours on every run across a full day** and completed on none of them. As a leg of the `build` matrix that made it a hard block on the npm publish, which had `needs: build`.

## The first attempt was wrong, and it is worth recording why

Adding `always()` to `publish-npm` does **not** help. `needs` waits for every leg to *finish* regardless; `always()` only decides whether the dependent runs once the wait is over. A permanently queued job blocks forever either way.

The runner had to **leave the dependency chain**, not have its result ignored.

## What changed

macOS Intel now builds in its own job with `continue-on-error`, outside the chain. When a runner frees up the asset is attached exactly as before. Until then a `darwin-x64` user gets `install.js`'s clean *"no standalone binary is published for this platform"* message and the pip fallback — an honest refusal rather than a broken install.

The pre-publish check treats **only** that asset as optional, scoped to the exact name rather than a wildcard. Linux and Windows stay mandatory: publishing without them would 404 for those users, and npm cannot republish a version to fix it.

**Relaxing the wait must not relax what the release promises.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4