### PR TITLE
Release 13.1.6 — the first fully automated release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,12 +7,12 @@
     {
       "name": "llm-router",
       "description": "Route text, image, video, and audio tasks to 20+ AI providers with smart routing, budget control, and multi-step orchestration",
-      "version": "13.1.5",
+      "version": "13.1.6",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"
       }
     }
   ],
-  "version": "13.1.5"
+  "version": "13.1.6"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.1.5",
+  "version": "13.1.6",
   "description": "Smart LLM routing with Claude subscription monitoring, complexity-first model selection, and 20+ AI providers",
   "author": {
     "name": "ypollak2",

--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Yali Pollak"
   },
-  "version": "13.1.5",
+  "version": "13.1.6",
   "plugins": [
     {
       "name": "llm-router",
       "description": "Route every Codex task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy.",
-      "version": "13.1.5",
+      "version": "13.1.6",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.1.5",
+  "version": "13.1.6",
   "description": "Route every Codex task to the cheapest capable model \u2014 Gemini Flash, Haiku, Ollama, Perplexity, and 20+ providers. Tracks cross-session savings, enforces routing policy.",
   "author": {
     "name": "ypollak2",

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "Yali Pollak"
   },
-  "version": "13.1.5",
+  "version": "13.1.6",
   "plugins": [
     {
       "name": "llm-router",
       "description": "Route every Droid task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy, and sends weekly Slack digests.",
-      "version": "13.1.5",
+      "version": "13.1.6",
       "source": {
         "source": "github",
         "repo": "ypollak2/llm-router"

--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-router",
-  "version": "13.1.5",
+  "version": "13.1.6",
   "description": "Route every Droid task to the cheapest capable model across 20+ AI providers. Tracks cross-session savings, enforces routing policy, and sends weekly Slack digests.",
   "author": {
     "name": "ypollak2",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-routing",
-  "version": "13.1.5",
+  "version": "13.1.6",
   "description": "Stop hitting the limit on your Claude Pro or Max plan. Routes routine prompts to free and cheap models so your subscription quota is there when you need it. No API keys.",
   "keywords": [
     "llm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-routing"
-version = "13.1.5"
+version = "13.1.6"
 description = "Multi-LLM router MCP server — smart complexity routing, budget-aware model selection, 20+ providers (Claude, OpenAI, Gemini, Ollama, etc.)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Everything the previous six tags fixed, exercised end to end for the first time:

```
build → attach → verify every asset install.js can request → publish to npm
```

with the ordering enforced by the workflow graph rather than by remembering it, and with a scarce macOS Intel runner no longer able to block any of it.

npm finally gets the README it has been missing since 13.1.4 — which is the whole reason this version exists. `package.json` listed one in `files` and the file did not exist, so a 3 kB package rendered nothing on npmjs.com and looked like a mistake. npm versions are immutable, so that could only be fixed forward.

## The seven bugs behind this

| tag | what broke |
|---|---|
| `v13.1.0` | a tag is not a release |
| `v13.1.1` | `contents: read` — the token could not write |
| `v13.1.2` | Windows packages a `.zip`, not a `.tar.gz` |
| `v13.1.3` | `nullglob` only drops patterns with wildcards — Linux regressed |
| `v13.1.4` | published by hand before any asset existed; no README |
| `v13.1.5` | a queued Intel runner blocked the publish forever |

Each is now covered by a test that executes the behaviour rather than matching text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4