### PR TITLE
Provenance needs id-token: write

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -324,6 +324,12 @@ jobs:
     environment: npm
     permissions:
       contents: read
+      # `npm publish --provenance` mints a signed attestation linking the
+      # package to this workflow run, and that needs an OIDC token. Without
+      # id-token: write the publish fails at the very last step, after the
+      # binaries are already attached — the same shape as the contents: read
+      # bug two releases ago.
+      id-token: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 

--- a/tests/test_npm_wrapper.py
+++ b/tests/test_npm_wrapper.py
@@ -425,3 +425,24 @@ def test_only_the_scarce_platform_is_optional():
     assert "*macos-x86_64*" in step, (
         "the optional case is not scoped to macOS Intel specifically"
     )
+
+
+def test_provenance_has_the_permission_it_requires():
+    """`npm publish --provenance` mints a signed attestation via OIDC.
+
+    Without id-token: write it fails at the very last step, after the binaries
+    are already attached — the same shape as the contents: read bug two
+    releases earlier. Both are permissions that fail at the END of a job, which
+    is the most expensive place for them to be wrong.
+    """
+    import yaml
+
+    wf_text = WORKFLOW.read_text()
+    wf = yaml.safe_load(wf_text)
+    perms = wf["jobs"]["publish-npm"]["permissions"]
+
+    if "--provenance" in wf_text:
+        assert perms.get("id-token") == "write", (
+            "publish uses --provenance but the job cannot mint an OIDC token; "
+            f"got {perms}"
+        )


### PR DESCRIPTION
`v13.1.6` built all three platforms, attached every asset, passed the pre-publish verification — and then **failed on `npm publish`**.

`--provenance` mints a signed attestation linking the package to the workflow run that produced it, which requires an **OIDC token**. The job granted only `contents: read`, so npm could not mint one.

This is the same shape as the `contents: read` bug two releases earlier: **a permission that fails at the END of a job**, after all the expensive work — the most costly place for it to be wrong. Second time in this file, so it is now asserted.

The test only fires when `--provenance` is actually in use, so dropping provenance later does not leave a stale requirement behind.

**Keeping provenance rather than dropping it:** it is the difference between a package anyone could have uploaded and one cryptographically tied to this repo and this commit — which matters more than usual for a package whose entire job is to download and execute a binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNWzQrGyfBdxpR75kYZG4