### PR TITLE
feat(seats): detect which subscriptions this machine is logged in to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **Seat detection.** `llm-router doctor` and the session banner now show which
+  subscriptions this machine is logged in to (Claude via `claude auth status`,
+  ChatGPT via `codex login status` plus the plan claim in the Codex login
+  token, Gemini CLI, Ollama) and the free bucket derived from them. Cached in
+  `~/.llm-router/seats.json`; kinds and plan names only, never tokens. A plan
+  claim past its window is reported as stale but still counts, because login
+  status is the fact and the claim a hint. First step of
+  `guide/PLAN_DUAL_HOST_INSTALL.md`.
 
 ## [13.0.8] — Close the second co-owned-file guard (2026-08-31)
 

--- a/guide/PLAN_DUAL_HOST_INSTALL.md
+++ b/guide/PLAN_DUAL_HOST_INSTALL.md
@@ -1,0 +1,169 @@
+# Plan: one install that wires Claude Code AND Codex, and knows which seats you pay for
+
+Status: proposed, 2026-09-04. Not started.
+
+## Goal
+
+A user with Claude Code and Codex CLI installed runs `pip install llm-routing && llm-router install`
+and, with no flags, gets:
+
+- llm-router registered as an MCP server in **both** hosts, so routing works in both directions
+  (cheap work from Claude Code lands on Codex/Ollama; hard work from Codex lands on the Claude seat).
+- A **seat table**: which subscriptions are logged in (Claude Max/Pro, ChatGPT Plus/Pro/Team,
+  Google account for Gemini CLI, local Ollama) and which API keys are set.
+- Routing defaults derived from that table, so a seat that is already paid for is the free tier and
+  API keys are used only where no seat covers the tier.
+- `llm-router doctor` that fails loudly when either host has lost its registration.
+
+Non-goals: fixing the Codex gateway wire format (`model_provider = "llm_router"`), Codex rate-limit
+pressure tracking, and any change to the classifier.
+
+## What is true today (verified on this machine, 2026-09-04)
+
+| Fact | Where |
+|---|---|
+| Claude Code → llm-router works. `llm_router` is in `~/.claude.json`; llm-router dispatches to `codex exec`. | `install_hooks.py:776`, `codex_agent.py` |
+| Codex → llm-router has **never** worked for anyone. The installer writes the MCP entry to `~/.codex/config.yaml`; Codex reads only `config.toml`. | `commands/install.py:525` |
+| A second, divergent Codex installer writes `~/.codex/config.json` and `~/.codex/rules/llm_router.md`. Codex reads neither. | `cli.py:590` |
+| Codex gateway mode (default for `--host codex`) is documented in-code as broken. | `codex_agent.py:318` |
+| doctor's Codex check validates `config.yaml`, so it reports OK for a broken install. | `commands/doctor.py:223` |
+| Subscription provider is a manual env var (`LLM_ROUTER_SUBSCRIPTION_PROVIDER`), never detected. | `subscription_local_routing.py:86` |
+| `claude auth status` returns JSON with `loggedIn`, `authMethod` (`claude.ai` vs API), `subscriptionType` (`max`/`pro`/…). Official, no keychain scraping. | verified |
+| `codex login status` prints `Logged in using ChatGPT` / `... an API key` / `Not logged in`. Plan type is a claim in the `id_token` JWT in `~/.codex/auth.json` (`chatgpt_plan_type`). | verified |
+| That claim can be stale: this machine's token says `plus`, active until 2026-07-12, yet Codex works today. Treat plan type as a hint, login status as the fact. | verified |
+| Gemini CLI: `gemini` binary + `~/.gemini/oauth_creds.json`. Not installed here. | — |
+| `codex mcp add <name> -- <cmd>` and `codex mcp list` exist in Codex 0.153. | verified |
+
+## Design
+
+### A. `llm_router/hosts.py` — host detection (new, pure)
+
+```
+detect_hosts() -> dict[str, HostInfo]   # {"claude-code": ..., "codex": ..., "gemini-cli": ...}
+HostInfo(binary: Path|None, config_dir: Path|None, version: str|None, present: bool)
+```
+Present = binary on PATH **or** config dir exists. No network. Injectable `home` and `which` for tests.
+
+### B. `llm_router/seats.py` — subscription detection (new)
+
+```
+detect_seats(timeout=3.0) -> Seats
+Seats(
+  claude:  Seat(kind="claude.ai"|"api-key"|None, plan="max"|"pro"|"team"|"enterprise"|None, source),
+  codex:   Seat(kind="chatgpt"|"api-key"|None, plan="plus"|"pro"|"team"|"business"|None, plan_stale: bool),
+  gemini:  Seat(kind="google"|"api-key"|None),
+  ollama:  Seat(kind="local"|None, models=[...]),
+  api_keys: {"OPENAI_API_KEY": bool, "GEMINI_API_KEY": bool, "ANTHROPIC_API_KEY": bool, ...},
+  detected_at: iso8601,
+)
+```
+Probes, in order, each with a timeout and each optional:
+
+- Claude: `claude auth status` → parse JSON. `authMethod == "claude.ai"` ⇒ seat; `subscriptionType` ⇒ plan.
+  Fallback: `ANTHROPIC_API_KEY` ⇒ api-key.
+- Codex: `codex login status` ⇒ kind. Then decode the JWT payload of `tokens.id_token` in
+  `~/.codex/auth.json` **without verification** (read-only, base64 only, no network) and read
+  `https://api.openai.com/auth.chatgpt_plan_type`. Set `plan_stale` when
+  `chatgpt_subscription_active_until` is in the past. Never store the token.
+- Gemini: binary present and `~/.gemini/oauth_creds.json` exists ⇒ google; else `GEMINI_API_KEY`.
+- Ollama: GET `127.0.0.1:11434/api/tags` (reuse existing probe).
+
+Persist to `~/.llm-router/seats.json`. Refresh on `install`, `doctor`, and the session-start hook
+(cheap: two subprocesses, ~200 ms). Stale after 24 h ⇒ doctor warns.
+
+### C. Seat-derived routing defaults
+
+In `chain_builder` / `subscription_local_routing`:
+
+- **Free bucket** = `ollama` ∪ {`codex` if codex seat is chatgpt} ∪ {`gemini_cli` if gemini seat is google}
+  ∪ {`claude` if claude seat is claude.ai}. Today `LOCAL_PROVIDERS` is a constant; make it a function
+  of `Seats`.
+- **Subscription provider** defaults to the claude seat when present; env var still overrides.
+- **Tier assignment**: fast → ollama, then codex; balanced → codex, then claude; best → claude seat
+  (subscription) when present, else codex, else API key. Same table used from either host, so the
+  "back" direction is the same code path — a Codex session calling `llm(task="analyze")` gets the
+  Claude seat.
+- API-key providers enter a chain only for a tier no seat covers, and doctor says so.
+
+### D. One Codex writer
+
+Delete `cli._install_codex_cli_files` and rewrite `commands.install._install_codex_files`:
+
+1. MCP: try `codex mcp add llm_router -- <abs path to llm-router>`; on failure, surgical insert of
+   `[mcp_servers.llm_router]` into `config.toml` with the existing `_ensure_toml_table_block`.
+   Absolute path because Codex does not inherit the shell PATH reliably. Record in the manifest.
+2. Instructions: marked block (`<!-- llm-router:start -->…<!-- llm-router:end -->`) appended to
+   `~/.codex/AGENTS.md`, replaced on re-run. Codex reads AGENTS.md; it does not read `rules/*.md`
+   or `instructions.md` (legacy).
+3. Migration: remove the `config.yaml` block, `config.json` entry, `rules/llm_router.md`,
+   `instructions.md` block, and any `model_provider = "llm_router"` this installer previously wrote,
+   using the manifest so hand-written content is untouched.
+4. Gateway mode becomes `--mode gateway` opt-in with a warning; default is MCP only.
+5. Keep the PostToolUse telemetry hook.
+6. Push routing, same as Claude Code: install a `UserPromptSubmit` hook in `~/.codex/hooks.json`
+   that runs the same auto-route script and injects the `⚡ ROUTE:` hint. Without it Codex is pull
+   only (it has to decide to call the tool from AGENTS.md); with it both hosts behave identically.
+
+### E. `llm-router install` with no `--host`
+
+1. `detect_hosts()`; `detect_seats()`.
+2. Install every present host (Claude Code path unchanged; Codex per D; Gemini CLI per existing writer).
+3. Print the seat table and the derived free bucket. `--host X` and `--skip-host X` remain.
+4. Exit non-zero if a present host could not be registered.
+
+### F. doctor
+
+- Replace the `config.yaml` check with: `[mcp_servers.llm_router]` in `config.toml`, command path
+  exists and is executable (same as the GH-41 Claude check), and `codex mcp list` shows it
+  (3 s timeout; "unsupported auth" column is fine).
+- Same for `claude mcp list`.
+- Print the seat table; warn if `seats.json` is older than 24 h or a plan claim is stale.
+- A present host with no registration is a **fail**, not a warn.
+
+### G. Session-start banner
+
+Add one line under the existing usage line: `seats: claude=max · codex=chatgpt(plus) · ollama=3 models`.
+
+### H. Project level (optional, last)
+
+`llm-router install --project` writes `AGENTS.md` (from a template naming the MCP tools) and a
+`CLAUDE.md` symlink to it (copy on Windows). Both agents read one file.
+
+## Delivery — four PRs, each green on its own
+
+| PR | Scope | Tests |
+|---|---|---|
+| 1 | `hosts.py`, `seats.py`, seat table in `doctor` and the banner. No behaviour change. | fake `claude`/`codex` shims on a temp PATH returning canned output; fake `auth.json` with a hand-built JWT; stale-claim case; every probe missing; timeout. |
+| 2 | Codex writer rewrite (D), host autodetect in `install` (E), doctor Codex checks (F), legacy migration. | temp `$HOME` with a hand-edited `config.toml` (must survive byte-for-byte outside the inserted table); `codex mcp add` shim failing ⇒ text fallback; re-run is idempotent; legacy files removed only when manifest says we wrote them. Update `test_codex_gateway_install.py`, `test_codex_self_heal.py`, `test_doctor_truth.py`. |
+| 3 | Seat-derived routing defaults (C). | chain_builder table tests per seat combination: {max, chatgpt}, {max only}, {chatgpt only}, {none, API keys}, {none, nothing} ⇒ expected chain per tier. |
+| 4 | `--project` (H). | symlink vs copy; existing AGENTS.md preserved. |
+
+Docs: update `guide/HOST_SUPPORT_MATRIX.md` (Codex from "Strong" to "Full" once PR2 lands),
+`guide/QUICKSTART_2MIN.md`, and the README install section.
+
+## Risks and decisions
+
+- **JWT plan claim staleness** — observed. Login status is authoritative; plan is advisory and
+  labelled stale when its window has passed.
+- **Hand-edited `config.toml`** — never rewrite the file; insert one table, remove only what the
+  manifest recorded.
+- **Absolute command path** — breaks when the venv moves. doctor checks the path; install re-run heals.
+- **Privacy** — seats.json stores kinds and plan names only, never tokens, emails, or account ids.
+- **No post-install hook** — pip has none and npm's must not edit `~/.codex`. "Automatic" means one
+  command detects and configures everything; same contract Claude Code has today.
+- **Decision needed**: should a Codex seat marked `plan_stale` still count as free? Proposed: yes,
+  because `codex exec` either works or fails fast, and the chain already skips a failing provider.
+
+## Acceptance
+
+Fresh machine, both CLIs logged in, Ollama running:
+
+```
+pip install llm-routing && llm-router install
+claude mcp list | grep llm_router      # present
+codex  mcp list | grep llm_router      # present
+llm-router doctor                      # seats table, no fails
+```
+From a Codex session: `llm(task="analyze", …)` is served by the Claude seat.
+From a Claude Code session: `llm(task="query", …)` is served by Ollama or Codex.
+Removing either CLI's login and re-running doctor shows the seat gone and the chain re-derived.

--- a/hooks/session-start.py
+++ b/hooks/session-start.py
@@ -741,6 +741,26 @@ def _refresh_claude_usage_attempt() -> dict:
         return {"success": False}
 
 
+def _seats_hint() -> str:
+    """One line naming the subscriptions this machine is logged in to.
+
+    Uses the cache written by install/doctor when it is fresh (24 h), and
+    re-detects with a short budget otherwise, so a session start never waits
+    on a slow CLI. Empty string when the seats module is unavailable.
+    """
+    try:
+        from llm_router import seats as _seats
+    except ImportError:
+        return ""
+    try:
+        cached = _seats.load_seats()
+        if cached is None or cached.is_stale():
+            cached = _seats.refresh_seats(timeout=2.0)
+    except Exception:  # noqa: BLE001
+        return ""
+    return "\n💺 Seats: " + cached.summary_line()
+
+
 def _weekly_digest() -> str:
     """Return a one-line weekly savings summary shown on Mondays (or after 6+ day gap).
 
@@ -1233,6 +1253,7 @@ def main() -> None:
     is_subscription = not usage_hint.startswith("\n⚠️")
 
     hints += usage_hint
+    hints += _seats_hint()
     hints += _format_learned_memory()
     hints += _weekly_digest()
     hints += _latency_hint()

--- a/src/llm_router/commands/doctor.py
+++ b/src/llm_router/commands/doctor.py
@@ -731,6 +731,55 @@ def _tool_surface_phantoms() -> list[str]:
     return found
 
 
+def _seats_report() -> list[str]:
+    """Detect seats (3 s budget), persist them, and render one line per seat."""
+    try:
+        from llm_router import seats as _seats
+        seats = _seats.refresh_seats()
+    except Exception as e:  # noqa: BLE001 -- doctor must never crash on a probe
+        return [_warn(f"seat detection failed: {e}")]
+
+    lines: list[str] = []
+    for name, seat in (
+        ("Claude", seats.claude),
+        ("Codex", seats.codex),
+        ("Gemini CLI", seats.gemini),
+        ("Ollama", seats.ollama),
+    ):
+        if seat.present:
+            text = f"{name:<11}{seat.label()}"
+            if seat.plan_stale:
+                lines.append(_warn(
+                    f"{text} -- the plan claim in the login token is past its window; "
+                    "login still works, so it still counts as a seat"
+                ))
+            else:
+                lines.append(_ok(text))
+        elif seat.kind == "api-key":
+            lines.append(_dim(f"    {name:<11}api key only (billed per call, not a seat)"))
+        else:
+            lines.append(_dim(f"    {name:<11}not logged in"))
+
+    bucket = sorted(seats.free_bucket())
+    if bucket:
+        lines.append(_ok(f"free bucket: {', '.join(bucket)}"))
+    else:
+        lines.append(_warn(
+            "no seat found -- every routed call is billed to an API key; "
+            "log in to Claude Code, Codex, or start Ollama to get a free tier"
+        ))
+    sub = seats.subscription_provider()
+    env_sub = os.environ.get("LLM_ROUTER_SUBSCRIPTION_PROVIDER", "").strip()
+    if sub and not env_sub:
+        lines.append(_dim(f"    subscription provider defaults to '{sub}' (from the Claude seat)"))
+    elif env_sub and sub and env_sub.lower() != sub:
+        lines.append(_warn(
+            f"LLM_ROUTER_SUBSCRIPTION_PROVIDER={env_sub} but the detected seat is '{sub}'"
+        ))
+    lines.append(_dim(f"    cached in ~/.llm-router/{_seats.SEATS_FILE_NAME}"))
+    return lines
+
+
 def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
     """Comprehensive health check — verify every component is wired up.
 
@@ -1129,6 +1178,15 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
                 issues.append("Usage data is stale")
 
     # ── 7. Provider keys ───────────────────────────────────────────────────
+    # ── 6b. Seats: which subscriptions this machine is logged in to ─────────
+    # A seat is a subscription already paid for, so routed work landing on it
+    # costs nothing extra. This is what the free bucket is derived from; a
+    # plan claim past its window is a hint, not a verdict (login status is
+    # the fact), so it warns and never fails.
+    print(f"\n{_bold('  Seats (subscriptions this machine is logged in to)')}")
+    for line in _seats_report():
+        print(f"  {line}")
+
     print(f"\n{_bold('  Provider API keys')}")
     for line in check_api_keys():
         print(f"  {line}")

--- a/src/llm_router/env_registry.py
+++ b/src/llm_router/env_registry.py
@@ -219,6 +219,7 @@ ENV_REGISTRY: dict[str, tuple[str, str, int]] = {
     "LLM_ROUTER_PROJECT_ID": ("provider_credential", "session_store.py", 1),
     "LLM_ROUTER_RESPONSE_ROUTER_TOKEN_THRESHOLD": ("provider_credential", "response_router.py", 1),
     "LLM_ROUTER_SCIM_TOKEN": ("provider_credential", "admin_api.py", 2),
+    "LLM_ROUTER_SUBSCRIPTION_PROVIDER": ("llm_router", "subscription_local_routing.py", 2),
     "LLM_ROUTER_TOKEN": ("provider_credential", "identity.py", 1),
     "DEEPSEEK_API_KEY": ("provider_credential", "commands/doctor.py", 1),
     "GEMINI_ACCESS_TOKEN": ("provider_credential", "invoice_reconciliation/gemini.py", 1),

--- a/src/llm_router/hooks/session-start.py
+++ b/src/llm_router/hooks/session-start.py
@@ -741,6 +741,26 @@ def _refresh_claude_usage_attempt() -> dict:
         return {"success": False}
 
 
+def _seats_hint() -> str:
+    """One line naming the subscriptions this machine is logged in to.
+
+    Uses the cache written by install/doctor when it is fresh (24 h), and
+    re-detects with a short budget otherwise, so a session start never waits
+    on a slow CLI. Empty string when the seats module is unavailable.
+    """
+    try:
+        from llm_router import seats as _seats
+    except ImportError:
+        return ""
+    try:
+        cached = _seats.load_seats()
+        if cached is None or cached.is_stale():
+            cached = _seats.refresh_seats(timeout=2.0)
+    except Exception:  # noqa: BLE001
+        return ""
+    return "\n💺 Seats: " + cached.summary_line()
+
+
 def _weekly_digest() -> str:
     """Return a one-line weekly savings summary shown on Mondays (or after 6+ day gap).
 
@@ -1233,6 +1253,7 @@ def main() -> None:
     is_subscription = not usage_hint.startswith("\n⚠️")
 
     hints += usage_hint
+    hints += _seats_hint()
     hints += _format_learned_memory()
     hints += _weekly_digest()
     hints += _latency_hint()

--- a/src/llm_router/host_detect.py
+++ b/src/llm_router/host_detect.py
@@ -1,0 +1,63 @@
+"""Which agent hosts are installed on this machine.
+
+A host is "present" when its binary is on PATH **or** its config directory
+exists. Either alone is enough: a user who installed Codex but has never run
+it has the binary and no ``~/.codex``; a user who runs Claude Code from an
+IDE extension may have ``~/.claude`` and no ``claude`` on the shell PATH.
+
+Pure and injectable: no network, no subprocesses. ``which`` and ``home`` are
+parameters so tests never touch the real machine.
+"""
+from __future__ import annotations
+
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable
+
+# host id -> (binary name, config dir relative to $HOME)
+_HOSTS: dict[str, tuple[str, str]] = {
+    "claude-code": ("claude", ".claude"),
+    "codex": ("codex", ".codex"),
+    "gemini-cli": ("gemini", ".gemini"),
+}
+
+
+@dataclass(frozen=True)
+class HostInfo:
+    host: str
+    binary: str | None
+    config_dir: str | None
+
+    @property
+    def present(self) -> bool:
+        return self.binary is not None or self.config_dir is not None
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["present"] = self.present
+        return d
+
+
+def detect_hosts(
+    *,
+    home: Path | None = None,
+    which: Callable[[str], str | None] = shutil.which,
+) -> dict[str, HostInfo]:
+    """Return every known host keyed by id, present or not."""
+    home = home or Path.home()
+    out: dict[str, HostInfo] = {}
+    for host, (binary, cfg) in _HOSTS.items():
+        found = which(binary)
+        cfg_dir = home / cfg
+        out[host] = HostInfo(
+            host=host,
+            binary=found,
+            config_dir=str(cfg_dir) if cfg_dir.is_dir() else None,
+        )
+    return out
+
+
+def present_hosts(**kw) -> list[str]:
+    """Ids of the hosts that are installed, in canonical order."""
+    return [h for h, info in detect_hosts(**kw).items() if info.present]

--- a/src/llm_router/seats.py
+++ b/src/llm_router/seats.py
@@ -1,0 +1,300 @@
+"""Which subscriptions ("seats") this machine is logged in to.
+
+A seat is a subscription the user already pays for, so routed work that
+lands on it costs nothing extra. Knowing the seats lets the installer derive
+the free bucket instead of asking for ``LLM_ROUTER_SUBSCRIPTION_PROVIDER``
+by hand, and lets doctor say which tier no seat covers.
+
+Sources, each optional and each with a timeout:
+
+- Claude:  ``claude auth status`` (JSON: ``authMethod``, ``subscriptionType``).
+           Official CLI output -- no keychain scraping.
+- Codex:   ``codex login status`` decides the kind. The plan name is a claim
+           in the ``id_token`` JWT in ``~/.codex/auth.json``; it is decoded
+           locally (base64 only, unverified, no network) and treated as a
+           HINT. The claim has been observed stale: a token can say the plan
+           ended weeks ago while Codex still works. Login status is the fact.
+- Gemini:  ``gemini`` binary plus ``~/.gemini/oauth_creds.json``.
+- Ollama:  GET ``/api/tags`` on the configured URL.
+- API keys: presence of the well-known env vars, never their values.
+
+Nothing here stores a token, an email, or an account id. ``seats.json``
+holds kinds and plan names only.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shutil
+import subprocess
+import time
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+SEATS_FILE_NAME = "seats.json"
+STALE_AFTER_SECONDS = 24 * 3600
+
+_API_KEY_VARS = (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "GROQ_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "MOONSHOT_API_KEY",
+)
+
+Runner = Callable[[list[str], float], "tuple[int, str] | None"]
+
+
+@dataclass(frozen=True)
+class Seat:
+    kind: str | None = None      # "claude.ai" | "chatgpt" | "google" | "local" | "api-key" | None
+    plan: str | None = None      # "max" | "pro" | "plus" | "team" | ... | None
+    plan_stale: bool = False     # the plan claim's own window has passed
+    models: tuple[str, ...] = ()  # ollama only
+
+    @property
+    def present(self) -> bool:
+        return self.kind is not None and self.kind != "api-key"
+
+    def label(self) -> str:
+        if self.kind is None:
+            return "none"
+        if self.kind == "api-key":
+            return "api-key"
+        if self.kind == "local":
+            return f"local({len(self.models)} models)" if self.models else "local"
+        plan = self.plan or "?"
+        if self.plan_stale:
+            plan += ",stale"
+        return f"{self.kind}({plan})"
+
+
+@dataclass(frozen=True)
+class Seats:
+    claude: Seat = field(default_factory=Seat)
+    codex: Seat = field(default_factory=Seat)
+    gemini: Seat = field(default_factory=Seat)
+    ollama: Seat = field(default_factory=Seat)
+    api_keys: dict[str, bool] = field(default_factory=dict)
+    detected_at: str = ""
+
+    def free_bucket(self) -> frozenset[str]:
+        """Providers that cost nothing extra: local + every logged-in seat.
+
+        A stale plan claim still counts. ``codex exec`` either works or
+        fails fast, and a failing provider is already skipped by the chain.
+        """
+        out = set()
+        if self.ollama.present:
+            out.add("ollama")
+        if self.codex.present:
+            out.add("codex")
+        if self.gemini.present:
+            out.add("gemini_cli")
+        if self.claude.present:
+            out.add("claude")
+        return frozenset(out)
+
+    def subscription_provider(self) -> str | None:
+        """Default for ``LLM_ROUTER_SUBSCRIPTION_PROVIDER`` when unset."""
+        return "claude" if self.claude.present else None
+
+    def summary_line(self) -> str:
+        return (
+            f"claude={self.claude.label()} · codex={self.codex.label()} · "
+            f"gemini={self.gemini.label()} · ollama={self.ollama.label()}"
+        )
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Seats":
+        def seat(x: dict | None) -> Seat:
+            x = x or {}
+            return Seat(
+                kind=x.get("kind"),
+                plan=x.get("plan"),
+                plan_stale=bool(x.get("plan_stale", False)),
+                models=tuple(x.get("models") or ()),
+            )
+        return cls(
+            claude=seat(d.get("claude")),
+            codex=seat(d.get("codex")),
+            gemini=seat(d.get("gemini")),
+            ollama=seat(d.get("ollama")),
+            api_keys=dict(d.get("api_keys") or {}),
+            detected_at=str(d.get("detected_at") or ""),
+        )
+
+    def age_seconds(self, now: float | None = None) -> float | None:
+        if not self.detected_at:
+            return None
+        try:
+            then = datetime.fromisoformat(self.detected_at).timestamp()
+        except ValueError:
+            return None
+        return (now if now is not None else time.time()) - then
+
+    def is_stale(self, now: float | None = None) -> bool:
+        age = self.age_seconds(now)
+        return age is None or age > STALE_AFTER_SECONDS
+
+
+# ── probes ──────────────────────────────────────────────────────────────────
+
+def _default_runner(argv: list[str], timeout: float) -> tuple[int, str] | None:
+    """Run a CLI and return (returncode, stdout+stderr), or None if it is
+    missing or hangs. Never raises."""
+    if shutil.which(argv[0]) is None:
+        return None
+    try:
+        proc = subprocess.run(
+            argv, capture_output=True, text=True, timeout=timeout, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def _detect_claude(runner: Runner, env: dict, timeout: float) -> Seat:
+    res = runner(["claude", "auth", "status"], timeout)
+    if res is not None:
+        code, out = res
+        try:
+            data = json.loads(out[out.index("{"):])
+        except (ValueError, json.JSONDecodeError):
+            data = {}
+        if data.get("loggedIn"):
+            method = str(data.get("authMethod") or "").lower()
+            plan = data.get("subscriptionType")
+            if method == "claude.ai":
+                return Seat(kind="claude.ai", plan=str(plan).lower() if plan else None)
+            # console / API-key login through the CLI: not a subscription seat
+            return Seat(kind="api-key")
+    if env.get("ANTHROPIC_API_KEY"):
+        return Seat(kind="api-key")
+    return Seat()
+
+
+def _jwt_payload(token: str) -> dict:
+    try:
+        part = token.split(".")[1]
+        part += "=" * (-len(part) % 4)
+        return json.loads(base64.urlsafe_b64decode(part))
+    except (IndexError, ValueError, json.JSONDecodeError):
+        return {}
+
+
+def _codex_plan_from_auth(home: Path, now: float) -> tuple[str | None, bool]:
+    """(plan, stale) from the id_token claim, or (None, False)."""
+    auth = home / ".codex" / "auth.json"
+    try:
+        data = json.loads(auth.read_text())
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None, False
+    tokens = data.get("tokens") or {}
+    claims = _jwt_payload(str(tokens.get("id_token") or ""))
+    auth_claims = claims.get("https://api.openai.com/auth") or {}
+    plan = auth_claims.get("chatgpt_plan_type")
+    until = auth_claims.get("chatgpt_subscription_active_until")
+    stale = False
+    if until:
+        try:
+            stale = datetime.fromisoformat(str(until)).timestamp() < now
+        except ValueError:
+            stale = False
+    return (str(plan).lower() if plan else None), stale
+
+
+def _detect_codex(runner: Runner, env: dict, home: Path, timeout: float, now: float) -> Seat:
+    res = runner(["codex", "login", "status"], timeout)
+    if res is not None:
+        _, out = res
+        low = out.lower()
+        if "logged in using chatgpt" in low:
+            plan, stale = _codex_plan_from_auth(home, now)
+            return Seat(kind="chatgpt", plan=plan, plan_stale=stale)
+        if "logged in" in low and "not logged in" not in low:
+            return Seat(kind="api-key")
+    if env.get("OPENAI_API_KEY"):
+        return Seat(kind="api-key")
+    return Seat()
+
+
+def _detect_gemini(env: dict, home: Path, which: Callable[[str], str | None]) -> Seat:
+    if which("gemini") and (home / ".gemini" / "oauth_creds.json").exists():
+        return Seat(kind="google")
+    if env.get("GEMINI_API_KEY") or env.get("GOOGLE_API_KEY"):
+        return Seat(kind="api-key")
+    return Seat()
+
+
+def _detect_ollama(env: dict, timeout: float, opener=urllib.request.urlopen) -> Seat:
+    url = env.get("OLLAMA_URL") or "http://localhost:11434"
+    try:
+        req = urllib.request.Request(f"{url}/api/tags", method="GET")
+        with opener(req, timeout=timeout) as resp:
+            data = json.loads(resp.read())
+    except Exception:
+        return Seat()
+    names = tuple(m.get("name", "") for m in data.get("models", []) if m.get("name"))
+    return Seat(kind="local", models=names)
+
+
+def detect_seats(
+    *,
+    timeout: float = 3.0,
+    runner: Runner = _default_runner,
+    env: dict | None = None,
+    home: Path | None = None,
+    which: Callable[[str], str | None] = shutil.which,
+    opener=urllib.request.urlopen,
+    now: float | None = None,
+) -> Seats:
+    env = dict(os.environ) if env is None else env
+    home = home or Path.home()
+    now = time.time() if now is None else now
+    return Seats(
+        claude=_detect_claude(runner, env, timeout),
+        codex=_detect_codex(runner, env, home, timeout, now),
+        gemini=_detect_gemini(env, home, which),
+        ollama=_detect_ollama(env, min(timeout, 2.0), opener),
+        api_keys={k: bool(env.get(k)) for k in _API_KEY_VARS},
+        detected_at=datetime.fromtimestamp(now, tz=timezone.utc).isoformat(),
+    )
+
+
+# ── persistence ─────────────────────────────────────────────────────────────
+
+def seats_path(home: Path | None = None) -> Path:
+    return (home or Path.home()) / ".llm-router" / SEATS_FILE_NAME
+
+
+def save_seats(seats: Seats, home: Path | None = None) -> Path:
+    path = seats_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(seats.to_dict(), indent=2))
+    return path
+
+
+def load_seats(home: Path | None = None) -> Seats | None:
+    path = seats_path(home)
+    try:
+        return Seats.from_dict(json.loads(path.read_text()))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def refresh_seats(home: Path | None = None, **kw) -> Seats:
+    """Detect and persist. The one call install, doctor and the hook share."""
+    seats = detect_seats(home=home, **kw)
+    save_seats(seats, home)
+    return seats

--- a/tests/test_doctor_seats.py
+++ b/tests/test_doctor_seats.py
@@ -1,0 +1,131 @@
+"""doctor and the session banner surface the detected seats."""
+from __future__ import annotations
+
+import json
+import pathlib
+
+from llm_router import seats as S
+from llm_router.commands import doctor as doc
+
+
+def _patch_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+
+def _fake_refresh(seats: S.Seats):
+    def refresh(home=None, **kw):
+        S.save_seats(seats, home)
+        return seats
+    return refresh
+
+
+def test_doctor_lists_every_seat_and_the_free_bucket(monkeypatch, tmp_path):
+    _patch_home(monkeypatch, tmp_path)
+    monkeypatch.delenv("LLM_ROUTER_SUBSCRIPTION_PROVIDER", raising=False)
+    seats = S.Seats(
+        claude=S.Seat(kind="claude.ai", plan="max"),
+        codex=S.Seat(kind="chatgpt", plan="plus", plan_stale=True),
+        gemini=S.Seat(kind="api-key"),
+        ollama=S.Seat(kind="local", models=("a", "b")),
+        detected_at="2026-09-04T00:00:00+00:00",
+    )
+    monkeypatch.setattr(S, "refresh_seats", _fake_refresh(seats))
+    text = "\n".join(doc._seats_report())
+    assert "claude.ai(max)" in text
+    assert "chatgpt(plus,stale)" in text and "past its window" in text
+    assert "Gemini CLI api key only" in text
+    assert "local(2 models)" in text
+    assert "free bucket: claude, codex, ollama" in text
+    assert "defaults to 'claude'" in text
+    # persisted for the session hook
+    assert (tmp_path / ".llm-router" / "seats.json").exists()
+
+
+def test_doctor_warns_when_no_seat_at_all(monkeypatch, tmp_path):
+    _patch_home(monkeypatch, tmp_path)
+    monkeypatch.setattr(S, "refresh_seats", _fake_refresh(S.Seats(detected_at="2026-09-04T00:00:00+00:00")))
+    text = "\n".join(doc._seats_report())
+    assert "no seat found" in text
+    assert "not logged in" in text
+
+
+def test_doctor_flags_env_override_that_disagrees_with_the_seat(monkeypatch, tmp_path):
+    _patch_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("LLM_ROUTER_SUBSCRIPTION_PROVIDER", "gemini")
+    seats = S.Seats(claude=S.Seat(kind="claude.ai", plan="pro"), detected_at="2026-09-04T00:00:00+00:00")
+    monkeypatch.setattr(S, "refresh_seats", _fake_refresh(seats))
+    text = "\n".join(doc._seats_report())
+    assert "LLM_ROUTER_SUBSCRIPTION_PROVIDER=gemini but the detected seat is 'claude'" in text
+
+
+def test_doctor_never_crashes_on_a_probe_error(monkeypatch, tmp_path):
+    _patch_home(monkeypatch, tmp_path)
+
+    def boom(**kw):
+        raise RuntimeError("probe exploded")
+    monkeypatch.setattr(S, "refresh_seats", boom)
+    text = "\n".join(doc._seats_report())
+    assert "seat detection failed: probe exploded" in text
+
+
+def test_doctor_run_includes_the_seats_section(monkeypatch, tmp_path, capsys):
+    _patch_home(monkeypatch, tmp_path)
+    monkeypatch.setattr(S, "refresh_seats", _fake_refresh(S.Seats(detected_at="2026-09-04T00:00:00+00:00")))
+    doc._run_doctor()
+    out = capsys.readouterr().out
+    assert "Seats (subscriptions this machine is logged in to)" in out
+
+
+def _load_session_start():
+    import importlib.util
+    path = pathlib.Path(doc.__file__).resolve().parent.parent / "hooks" / "session-start.py"
+    spec = importlib.util.spec_from_file_location("llm_router_session_start_hook", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_session_banner_uses_fresh_cache_without_redetecting(monkeypatch, tmp_path):
+    _patch_home(monkeypatch, tmp_path)
+    seats = S.Seats(claude=S.Seat(kind="claude.ai", plan="max"))
+    fresh = S.Seats.from_dict({**seats.to_dict(), "detected_at": S.datetime.now(S.timezone.utc).isoformat()})
+    S.save_seats(fresh, tmp_path)
+
+    def must_not_run(**kw):
+        raise AssertionError("re-detected despite a fresh cache")
+    monkeypatch.setattr(S, "refresh_seats", must_not_run)
+    hook = _load_session_start()
+    assert hook._seats_hint() == "\n💺 Seats: " + fresh.summary_line()
+
+
+def test_session_banner_redetects_a_stale_cache(monkeypatch, tmp_path):
+    _patch_home(monkeypatch, tmp_path)
+    S.save_seats(S.Seats(detected_at="2000-01-01T00:00:00+00:00"), tmp_path)
+    seats = S.Seats(codex=S.Seat(kind="chatgpt", plan="pro"), detected_at="2026-09-04T00:00:00+00:00")
+    calls = []
+
+    def refresh(**kw):
+        calls.append(kw)
+        return seats
+    monkeypatch.setattr(S, "refresh_seats", refresh)
+    hook = _load_session_start()
+    assert "codex=chatgpt(pro)" in hook._seats_hint()
+    assert calls and calls[0].get("timeout") == 2.0
+
+
+def test_session_banner_is_silent_on_error(monkeypatch, tmp_path):
+    _patch_home(monkeypatch, tmp_path)
+
+    def boom(**kw):
+        raise OSError("nope")
+    monkeypatch.setattr(S, "refresh_seats", boom)
+    assert _load_session_start()._seats_hint() == ""
+
+
+def test_seats_json_shape_is_stable(tmp_path):
+    """The hook, doctor, and install all read this file; pin its keys."""
+    S.save_seats(S.Seats(detected_at="2026-09-04T00:00:00+00:00"), tmp_path)
+    data = json.loads((tmp_path / ".llm-router" / "seats.json").read_text())
+    assert set(data) == {"claude", "codex", "gemini", "ollama", "api_keys", "detected_at"}
+    assert set(data["claude"]) == {"kind", "plan", "plan_stale", "models"}

--- a/tests/test_seats_detection.py
+++ b/tests/test_seats_detection.py
@@ -1,0 +1,304 @@
+"""Seat and host detection: which subscriptions this machine is logged in to.
+
+Every probe is injected -- no real CLI, no network, no real $HOME -- so the
+suite runs the same on a dev laptop and in CI.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from llm_router import seats as S
+from llm_router.host_detect import detect_hosts, present_hosts
+
+NOW = 1_790_000_000.0  # fixed clock
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+def _jwt(claims: dict) -> str:
+    body = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"eyJhbGciOiJub25lIn0.{body}.sig"
+
+
+def _codex_auth(home: Path, plan: str = "plus", until: str | None = None) -> None:
+    auth = {"https://api.openai.com/auth": {"chatgpt_plan_type": plan}}
+    if until:
+        auth["https://api.openai.com/auth"]["chatgpt_subscription_active_until"] = until
+    (home / ".codex").mkdir(parents=True, exist_ok=True)
+    (home / ".codex" / "auth.json").write_text(json.dumps({
+        "tokens": {"id_token": _jwt(auth), "access_token": "x", "refresh_token": "y"},
+    }))
+
+
+def _runner(table: dict[str, tuple[int, str] | None]):
+    """Fake CLI runner keyed by the first two argv words."""
+    def run(argv, timeout):
+        return table.get(" ".join(argv[:2]))
+    return run
+
+
+class _Resp:
+    def __init__(self, payload: dict):
+        self._b = json.dumps(payload).encode()
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _opener(models: list[str] | None):
+    def open_(req, timeout):
+        if models is None:
+            raise OSError("connection refused")
+        return _Resp({"models": [{"name": m} for m in models]})
+    return open_
+
+
+def _detect(tmp_path, *, runner=None, env=None, models=None, which=lambda b: None, now=NOW):
+    return S.detect_seats(
+        runner=runner or _runner({}),
+        env=env or {},
+        home=tmp_path,
+        which=which,
+        opener=_opener(models),
+        now=now,
+    )
+
+
+CLAUDE_MAX = (0, json.dumps({"loggedIn": True, "authMethod": "claude.ai", "subscriptionType": "max"}))
+CLAUDE_CONSOLE = (0, json.dumps({"loggedIn": True, "authMethod": "console", "apiProvider": "firstParty"}))
+CLAUDE_OUT = (0, json.dumps({"loggedIn": False}))
+CODEX_CHATGPT = (0, "Logged in using ChatGPT\n")
+CODEX_KEY = (0, "Logged in using an API key\n")
+CODEX_OUT = (1, "Not logged in\n")
+
+
+# ── claude ──────────────────────────────────────────────────────────────────
+
+def test_claude_max_seat_from_auth_status(tmp_path):
+    seats = _detect(tmp_path, runner=_runner({"claude auth": CLAUDE_MAX}))
+    assert seats.claude == S.Seat(kind="claude.ai", plan="max")
+    assert seats.claude.present
+
+
+def test_claude_console_login_is_an_api_key_not_a_seat(tmp_path):
+    seats = _detect(tmp_path, runner=_runner({"claude auth": CLAUDE_CONSOLE}))
+    assert seats.claude.kind == "api-key"
+    assert not seats.claude.present
+
+
+def test_claude_logged_out_falls_back_to_env_key(tmp_path):
+    seats = _detect(tmp_path, runner=_runner({"claude auth": CLAUDE_OUT}), env={"ANTHROPIC_API_KEY": "k"})
+    assert seats.claude.kind == "api-key"
+
+
+def test_claude_cli_missing_and_no_key_is_no_seat(tmp_path):
+    seats = _detect(tmp_path)
+    assert seats.claude == S.Seat()
+
+
+def test_claude_status_with_leading_noise_still_parses(tmp_path):
+    noisy = (0, "warning: something\n" + CLAUDE_MAX[1])
+    seats = _detect(tmp_path, runner=_runner({"claude auth": noisy}))
+    assert seats.claude.plan == "max"
+
+
+# ── codex ───────────────────────────────────────────────────────────────────
+
+def test_codex_chatgpt_seat_with_plan_from_token(tmp_path):
+    _codex_auth(tmp_path, plan="pro", until="2099-01-01T00:00:00+00:00")
+    seats = _detect(tmp_path, runner=_runner({"codex login": CODEX_CHATGPT}))
+    assert seats.codex == S.Seat(kind="chatgpt", plan="pro", plan_stale=False)
+
+
+def test_codex_plan_claim_past_its_window_is_marked_stale_but_still_a_seat(tmp_path):
+    """Observed in the wild: the id_token said the plan ended weeks ago while
+    `codex exec` kept working. Login status is the fact, the claim a hint."""
+    _codex_auth(tmp_path, plan="plus", until="2020-01-01T00:00:00+00:00")
+    seats = _detect(tmp_path, runner=_runner({"codex login": CODEX_CHATGPT}))
+    assert seats.codex.kind == "chatgpt"
+    assert seats.codex.plan == "plus"
+    assert seats.codex.plan_stale is True
+    assert seats.codex.present
+    assert "codex" in seats.free_bucket()
+    assert "stale" in seats.codex.label()
+
+
+def test_codex_chatgpt_without_auth_file_has_no_plan(tmp_path):
+    seats = _detect(tmp_path, runner=_runner({"codex login": CODEX_CHATGPT}))
+    assert seats.codex == S.Seat(kind="chatgpt", plan=None)
+
+
+def test_codex_garbage_auth_file_does_not_raise(tmp_path):
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".codex" / "auth.json").write_text("{not json")
+    seats = _detect(tmp_path, runner=_runner({"codex login": CODEX_CHATGPT}))
+    assert seats.codex.kind == "chatgpt" and seats.codex.plan is None
+
+
+def test_codex_api_key_login_is_not_a_seat(tmp_path):
+    seats = _detect(tmp_path, runner=_runner({"codex login": CODEX_KEY}))
+    assert seats.codex.kind == "api-key"
+    assert "codex" not in seats.free_bucket()
+
+
+def test_codex_logged_out_then_env_key(tmp_path):
+    seats = _detect(tmp_path, runner=_runner({"codex login": CODEX_OUT}), env={"OPENAI_API_KEY": "k"})
+    assert seats.codex.kind == "api-key"
+
+
+def test_codex_cli_hang_returns_none_and_is_no_seat(tmp_path):
+    seats = _detect(tmp_path, runner=_runner({"codex login": None}))
+    assert seats.codex == S.Seat()
+
+
+# ── gemini / ollama / keys ──────────────────────────────────────────────────
+
+def test_gemini_google_seat_needs_binary_and_creds(tmp_path):
+    (tmp_path / ".gemini").mkdir()
+    (tmp_path / ".gemini" / "oauth_creds.json").write_text("{}")
+    assert _detect(tmp_path, which=lambda b: "/usr/bin/gemini" if b == "gemini" else None).gemini.kind == "google"
+    assert _detect(tmp_path).gemini.kind is None  # no binary
+
+
+def test_gemini_env_key_without_login(tmp_path):
+    assert _detect(tmp_path, env={"GEMINI_API_KEY": "k"}).gemini.kind == "api-key"
+
+
+def test_ollama_seat_lists_models(tmp_path):
+    seats = _detect(tmp_path, models=["qwen3-coder:30b", "lfm2.5:8b"])
+    assert seats.ollama.kind == "local"
+    assert seats.ollama.models == ("qwen3-coder:30b", "lfm2.5:8b")
+    assert seats.ollama.label() == "local(2 models)"
+
+
+def test_ollama_down_is_no_seat(tmp_path):
+    assert _detect(tmp_path, models=None).ollama == S.Seat()
+
+
+def test_api_keys_are_booleans_never_values(tmp_path):
+    seats = _detect(tmp_path, env={"OPENAI_API_KEY": "sk-secret", "GROQ_API_KEY": ""})
+    assert seats.api_keys["OPENAI_API_KEY"] is True
+    assert seats.api_keys["GROQ_API_KEY"] is False
+    assert "sk-secret" not in json.dumps(seats.to_dict())
+
+
+# ── derived routing facts ───────────────────────────────────────────────────
+
+def test_free_bucket_is_local_plus_every_seat(tmp_path):
+    _codex_auth(tmp_path)
+    seats = _detect(
+        tmp_path,
+        runner=_runner({"claude auth": CLAUDE_MAX, "codex login": CODEX_CHATGPT}),
+        models=["m"],
+    )
+    assert seats.free_bucket() == frozenset({"ollama", "codex", "claude"})
+    assert seats.subscription_provider() == "claude"
+
+
+def test_no_seats_means_empty_bucket_and_no_subscription_default(tmp_path):
+    seats = _detect(tmp_path, env={"OPENAI_API_KEY": "k"})
+    assert seats.free_bucket() == frozenset()
+    assert seats.subscription_provider() is None
+
+
+def test_summary_line_names_every_seat(tmp_path):
+    seats = _detect(tmp_path, runner=_runner({"claude auth": CLAUDE_MAX}), models=["m"])
+    assert seats.summary_line() == "claude=claude.ai(max) · codex=none · gemini=none · ollama=local(1 models)"
+
+
+# ── persistence ─────────────────────────────────────────────────────────────
+
+def test_save_load_roundtrip_and_no_secrets_on_disk(tmp_path):
+    _codex_auth(tmp_path, plan="team", until="2099-01-01T00:00:00+00:00")
+    seats = _detect(
+        tmp_path,
+        runner=_runner({"claude auth": CLAUDE_MAX, "codex login": CODEX_CHATGPT}),
+        env={"OPENAI_API_KEY": "sk-secret"},
+        models=["m"],
+    )
+    path = S.save_seats(seats, tmp_path)
+    assert path == tmp_path / ".llm-router" / "seats.json"
+    text = path.read_text()
+    assert "sk-secret" not in text and "id_token" not in text and "eyJ" not in text
+    assert S.load_seats(tmp_path) == seats
+
+
+def test_load_missing_or_corrupt_returns_none(tmp_path):
+    assert S.load_seats(tmp_path) is None
+    S.seats_path(tmp_path).parent.mkdir(parents=True)
+    S.seats_path(tmp_path).write_text("nope")
+    assert S.load_seats(tmp_path) is None
+
+
+def test_staleness_is_24h(tmp_path):
+    seats = _detect(tmp_path, now=NOW)
+    assert not seats.is_stale(now=NOW + 3600)
+    assert seats.is_stale(now=NOW + S.STALE_AFTER_SECONDS + 1)
+    assert S.Seats().is_stale()  # never detected
+
+
+def test_refresh_detects_and_persists(tmp_path):
+    seats = S.refresh_seats(
+        home=tmp_path, runner=_runner({"claude auth": CLAUDE_MAX}), env={},
+        which=lambda b: None, opener=_opener(None), now=NOW,
+    )
+    assert seats.claude.plan == "max"
+    assert S.load_seats(tmp_path) == seats
+
+
+# ── default runner ──────────────────────────────────────────────────────────
+
+def test_default_runner_returns_none_for_missing_binary():
+    assert S._default_runner(["definitely-not-a-real-binary-xyz", "x"], 1.0) is None
+
+
+def test_default_runner_captures_output():
+    code, out = S._default_runner(["python3", "-c", "print('hi')"], 10.0)
+    assert code == 0 and "hi" in out
+
+
+# ── hosts ───────────────────────────────────────────────────────────────────
+
+def test_host_present_by_binary_or_config_dir(tmp_path):
+    (tmp_path / ".codex").mkdir()
+    hosts = detect_hosts(home=tmp_path, which=lambda b: "/usr/local/bin/claude" if b == "claude" else None)
+    assert hosts["claude-code"].present and hosts["claude-code"].binary == "/usr/local/bin/claude"
+    assert hosts["claude-code"].config_dir is None
+    assert hosts["codex"].present and hosts["codex"].binary is None
+    assert hosts["codex"].config_dir == str(tmp_path / ".codex")
+    assert not hosts["gemini-cli"].present
+    assert present_hosts(home=tmp_path, which=lambda b: None) == ["codex"]
+
+
+def test_host_config_file_is_not_a_config_dir(tmp_path):
+    (tmp_path / ".gemini").write_text("")  # a file, not a dir
+    assert not detect_hosts(home=tmp_path, which=lambda b: None)["gemini-cli"].present
+
+
+def test_host_info_to_dict_carries_present(tmp_path):
+    d = detect_hosts(home=tmp_path, which=lambda b: None)["codex"].to_dict()
+    assert d == {"host": "codex", "binary": None, "config_dir": None, "present": False}
+
+
+@pytest.mark.parametrize("age", [0, 100])
+def test_age_seconds_uses_detected_at(tmp_path, age):
+    seats = _detect(tmp_path, now=NOW)
+    assert seats.age_seconds(now=NOW + age) == pytest.approx(age)
+    assert S.Seats().age_seconds() is None
+
+
+def test_real_time_default_is_now(tmp_path):
+    before = time.time()
+    seats = S.detect_seats(runner=_runner({}), env={}, home=tmp_path, which=lambda b: None, opener=_opener(None))
+    assert 0 <= (seats.age_seconds() or 0) <= max(5.0, time.time() - before + 1)


### PR DESCRIPTION
PR 1 of 4 from `guide/PLAN_DUAL_HOST_INSTALL.md` (included). No routing behaviour changes.

**Why.** A seat is a subscription the user already pays for, so routed work landing on it costs nothing extra. The router could only learn about one via `LLM_ROUTER_SUBSCRIPTION_PROVIDER` by hand. The plan also records a finding: Codex → llm-router has never worked for anyone, because the installer writes `~/.codex/config.yaml` and Codex reads only `config.toml`. That is PR 2.

**What.**
- `host_detect.py`: which agent hosts are installed (binary on PATH or config dir).
- `seats.py`: Claude via `claude auth status` (JSON, official), ChatGPT via `codex login status` plus the `chatgpt_plan_type` claim in the login token, decoded locally and treated as a hint. The claim has been observed stale while login still works, so login status is the fact. Gemini CLI, Ollama, and which API-key env vars are set. Persisted to `~/.llm-router/seats.json`: kinds and plan names only, never tokens.
- `doctor`: a Seats section with the derived free bucket. Warns, never fails.
- Session banner: one `💺 Seats:` line, served from the cache when it is under 24 h old.
- `env_registry`: `LLM_ROUTER_SUBSCRIPTION_PROVIDER` was read but never declared.

**Tests.** 41 new, all probes injected (fake CLIs, hand-built JWT, no network, temp `$HOME`). Full suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LktEjGmgYMKstVfPC7NGtt