### PR TITLE
fix(codex): one installer that writes what Codex reads, and trusts its hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Codex → llm-router works, for the first time.** The installer wrote the
+  MCP server to `~/.codex/config.yaml` (and an older path to `config.json`
+  and `rules/llm_router.md`). Codex reads only `config.toml`, so no Codex
+  session has ever seen llm-router. One writer now targets
+  `[mcp_servers.llm_router]` in `config.toml` (via `codex mcp add`, TOML
+  fallback), `hooks.json`, and a marked block in `AGENTS.md`, and removes the
+  legacy entries when they are ours. The duplicate installer in `cli.py` is
+  gone.
+- **Codex hooks now actually run.** Codex 0.153 silently skips any hook in
+  `hooks.json` without a `[hooks.state."…"] trusted_hash` record in
+  `config.toml`. `llm_router.codex_host` computes the hash (verified against a
+  real run) and install writes it for every hook it installs; doctor fails on
+  a missing or stale record.
+- `llm-router doctor --host codex` validated `config.yaml` and reported a
+  broken install as healthy. It now checks `config.toml`, that the command
+  can start, `codex mcp list`, hook trust, and `AGENTS.md`.
+
 ### Added
+
+- **`llm-router install` auto-detects Codex.** With no `--host`, a machine
+  that has Codex gets it wired in the same run, and the seat table prints at
+  the end. `--no-hosts` opts out; `--host codex` is unchanged. Gateway mode is
+  opt-in (`--mode gateway`), no longer the Codex default.
+- **Codex gets push routing.** A `UserPromptSubmit` hook injects the same
+  `⚡ ROUTE:` hint Claude Code gets. `hosts/events.py` now carries the verified
+  Codex prompt payload keys (fixture from a real run).
 
 - **Seat detection.** `llm-router doctor` and the session banner now show which
   subscriptions this machine is logged in to (Claude via `claude auth status`,

--- a/guide/HOST_SUPPORT_MATRIX.md
+++ b/guide/HOST_SUPPORT_MATRIX.md
@@ -33,7 +33,7 @@ it, **🔜** means we haven't built it.
 | Host | Prompt-interception hook | Can it block? | Status here |
 |---|---|:---:|---|
 | Claude Code | `UserPromptSubmit` | yes | shipped |
-| Codex CLI | `UserPromptSubmit` | yes — `{"decision":"block"}` | not yet |
+| Codex CLI | `UserPromptSubmit` | yes — `{"decision":"block"}` | shipped (`llm-router install`; hook trust record written to config.toml) |
 | Cursor | `beforeSubmitPrompt` | yes | not yet |
 | Gemini CLI | `UserPromptSubmit` | yes | shipped |
 
@@ -83,39 +83,44 @@ llm-router install
 
 ---
 
-### 🟡 Codex CLI (Strong)
+### 🟢 Codex CLI (Full)
 
-**Tier: Explicit MCP Routing**
+**Tier: Automatic Routing (push) + MCP**
 
-OpenAI's agent runner. llm-router MCP tools can be called from Codex, but
-native Codex turns do not pass through llm-router.
+OpenAI's agent runner. `llm-router install` detects Codex and wires it the
+same way it wires Claude Code, so routing works in both directions: cheap
+work from Claude Code lands on the ChatGPT seat, hard work from Codex lands
+on the Claude seat.
 
 **Activation:**
 ```bash
-llm-router install --host codex
+llm-router install            # auto-detects Codex; or: --host codex
+llm-router doctor             # Codex CLI section + Seats table
 ```
 
+**What is written (verified against Codex 0.153):**
+- `~/.codex/config.toml` — `[mcp_servers.llm_router]` (via `codex mcp add`, TOML
+  fallback) and a `[hooks.state."…"] trusted_hash` record per hook. Codex
+  silently skips a hook without that record; earlier installers never wrote it.
+- `~/.codex/hooks.json` — `UserPromptSubmit` → auto-route (the ⚡ ROUTE hint),
+  `PostToolUse` → telemetry.
+- `~/.codex/AGENTS.md` — a marked block of routing rules, replaced on re-run.
+
+Earlier versions wrote `config.yaml`, `config.json`, `rules/llm_router.md`
+and `instructions.md`. Codex reads none of them; install removes ours.
+
 **Features:**
-- ✅ Explicit MCP routing via `llm_auto` and routed tools
-- ✅ Tracks calls made through llm-router MCP tools
+- ✅ Push routing: the same ⚡ ROUTE hint Claude Code gets, on every prompt
+- ✅ MCP routing via `llm_auto` and routed tools
 - ✅ Codex injected as free tier 1 in all chains
-- ✅ Cost tracking via SQLite
-- ✅ Decision analytics
-
-**Cost savings:** Up to 60–80% for tasks explicitly sent through llm-router
-
-**Why it is useful:**
-- Codex CLI runtime is purpose-built for agent work
-- Codex injected automatically within explicitly invoked routing chains
-- Routed-call analytics are available
+- ✅ Cost tracking via SQLite; decision analytics
 
 **Limitations:**
 - Requires Codex CLI installed locally
-- No automatic routing for native Codex turns
+- PreToolUse payload keys are not yet captured, so `enforce-route` is Claude Code only
 - No native Codex turn/token metering in `llm_session_spend`
-- No real-time quota pressure display (use `llm-router budget` manually)
-
----
+- Gateway mode (`--mode gateway`) is opt-in: the gateway does not yet speak
+  Codex's "responses" wire format
 
 ### 🟡 Gemini CLI (Strong)
 

--- a/guide/PLAN_DUAL_HOST_INSTALL.md
+++ b/guide/PLAN_DUAL_HOST_INSTALL.md
@@ -1,6 +1,6 @@
 # Plan: one install that wires Claude Code AND Codex, and knows which seats you pay for
 
-Status: proposed, 2026-09-04. Not started.
+Status: 2026-09-04 — PR 1 (#128, seats) open; PR 2 (Codex writer, autodetect, doctor, push hook) on `feat/codex-dual-host`. PR 3, 4 not started.
 
 ## Goal
 
@@ -103,6 +103,10 @@ Delete `cli._install_codex_cli_files` and rewrite `commands.install._install_cod
 6. Push routing, same as Claude Code: install a `UserPromptSubmit` hook in `~/.codex/hooks.json`
    that runs the same auto-route script and injects the `⚡ ROUTE:` hint. Without it Codex is pull
    only (it has to decide to call the tool from AGENTS.md); with it both hosts behave identically.
+   **Found while building:** Codex silently skips any hook without a
+   `[hooks.state."<hooks.json>:<event>:<group>:<handler>"] trusted_hash` record in `config.toml`.
+   The hash is SHA-256 of a canonical-JSON identity of the hook (`llm_router.codex_host`), verified
+   against a real run. The real `UserPromptSubmit` payload is in `tests/fixtures/`.
 
 ### E. `llm-router install` with no `--host`
 

--- a/src/llm_router/cli.py
+++ b/src/llm_router/cli.py
@@ -587,28 +587,6 @@ def _install_pi_files() -> list[str]:
     return actions
 
 
-def _install_codex_cli_files() -> list[str]:
-    """Install llm_router MCP config for Codex CLI."""
-    actions = []
-    home = Path.home()
-
-    # Codex CLI config location
-    config_json = home / ".codex" / "config.json"
-    actions.extend(
-        _merge_json_mcp_block(
-            config_json,
-            "llm_router",
-            {"command": "llm-router", "args": []},
-        )
-    )
-
-    # Add Codex rules
-    rules_file = home / ".codex" / "rules" / "llm_router.md"
-    actions.extend(_append_routing_rules(rules_file, "codex-rules.md"))
-
-    return actions
-
-
 def _print_claude_desktop_config() -> list[str]:
     """Print Claude Desktop config snippet."""
     config = {
@@ -684,7 +662,10 @@ def _install_host(host: str) -> None:
         for action in actions:
             print(f"  {action}")
     elif host == "codex":
-        actions = _install_codex_cli_files()
+        # One implementation only (RED8-06): the real writer lives in
+        # commands/install.py and targets config.toml, hooks.json, AGENTS.md.
+        from llm_router.commands.install import _install_codex_files
+        actions = _install_codex_files()
         print("Codex CLI configuration:")
         for action in actions:
             print(f"  {action}")

--- a/src/llm_router/codex_host.py
+++ b/src/llm_router/codex_host.py
@@ -1,0 +1,232 @@
+"""Pure helpers for wiring llm-router into Codex CLI.
+
+Everything Codex-specific that can be computed without touching the
+filesystem lives here, so the installer and doctor share one definition and
+the tests can pin it.
+
+Two facts about Codex (0.153, verified 2026-09-04 against a real run) drive
+this module:
+
+1. Codex reads MCP servers from ``~/.codex/config.toml`` under
+   ``[mcp_servers.<name>]``. Not ``config.yaml``, not ``config.json``.
+2. Codex **silently skips** a hook from ``hooks.json`` unless
+   ``config.toml`` carries a matching trust record::
+
+       [hooks.state."<abs hooks.json>:<event_label>:<group>:<handler>"]
+       trusted_hash = "sha256:<hex>"
+
+   The hash is over a normalized identity of the hook, not the file text
+   (codex-rs/hooks/src/engine/discovery.rs ``hook_hash`` +
+   codex-rs/config/src/fingerprint.rs ``version_for_toml``): the handler
+   config with defaults filled in, wrapped with the event label, serialized
+   as canonical JSON (keys sorted recursively, no whitespace), SHA-256.
+   An installer that writes the hook without the record installs nothing.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+DEFAULT_HOOK_TIMEOUT_SEC = 600
+SESSION_END_DEFAULT_TIMEOUT_SEC = 30  # clamped separately by Codex; we never install one
+
+MCP_SERVER_NAME = "llm_router"
+MCP_TABLE = f"mcp_servers.{MCP_SERVER_NAME}"
+
+# Routing doors that `codex exec` (approval policy "never") must be able to
+# call without a prompt. Admin and agent-session tools are deliberately absent.
+APPROVED_TOOLS = ("llm", "llm_act", "llm_edit", "llm_image", "llm_audio", "llm_route",
+                  "llm_router_status", "llm_router_session")
+
+AGENTS_BLOCK_START = "<!-- llm-router:start -->"
+AGENTS_BLOCK_END = "<!-- llm-router:end -->"
+
+# Codex event name -> label used in state keys and the hashed identity.
+EVENT_LABELS = {
+    "PreToolUse": "pre_tool_use",
+    "PermissionRequest": "permission_request",
+    "PostToolUse": "post_tool_use",
+    "PreCompact": "pre_compact",
+    "PostCompact": "post_compact",
+    "SessionStart": "session_start",
+    "SessionEnd": "session_end",
+    "UserPromptSubmit": "user_prompt_submit",
+    "SubagentStart": "subagent_start",
+    "SubagentStop": "subagent_stop",
+    "Stop": "stop",
+}
+
+# Events whose matcher survives normalization. For the others Codex drops it
+# before hashing (codex-rs/hooks/src/events/common.rs matcher_pattern_for_event).
+EVENTS_WITH_MATCHER = frozenset({
+    "PreToolUse", "PermissionRequest", "PostToolUse", "SessionStart", "SessionEnd",
+    "SubagentStart", "SubagentStop", "PreCompact", "PostCompact",
+})
+
+
+def _canonical(value):
+    if isinstance(value, dict):
+        return {k: _canonical(value[k]) for k in sorted(value)}
+    if isinstance(value, list):
+        return [_canonical(v) for v in value]
+    return value
+
+
+def hook_trust_hash(event: str, handler: dict, matcher: str | None = None) -> str:
+    """The ``trusted_hash`` Codex expects for one command hook.
+
+    ``handler`` is the JSON object from hooks.json (``type``, ``command``,
+    optional ``timeout``, ``async``, ``statusMessage``,
+    ``additionalContextLimit``). Only ``type: command`` is supported here.
+    """
+    if event not in EVENT_LABELS:
+        raise ValueError(f"unknown Codex hook event {event!r}")
+    if handler.get("type", "command") != "command":
+        raise ValueError("only command hooks are supported")
+    normalized: dict = {
+        "type": "command",
+        "command": handler["command"],
+        "timeout": int(handler.get("timeout") or DEFAULT_HOOK_TIMEOUT_SEC),
+        "async": bool(handler.get("async", False)),
+    }
+    if handler.get("statusMessage"):
+        normalized["statusMessage"] = handler["statusMessage"]
+    limit = handler.get("additionalContextLimit")
+    if limit is not None and limit != 2500:
+        normalized["additionalContextLimit"] = limit
+    identity: dict = {"event_name": EVENT_LABELS[event], "hooks": [normalized]}
+    if event in EVENTS_WITH_MATCHER and matcher is not None:
+        identity["matcher"] = matcher
+    payload = json.dumps(_canonical(identity), separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def hook_state_key(hooks_json: Path | str, event: str, group_index: int, handler_index: int) -> str:
+    return f"{hooks_json}:{EVENT_LABELS[event]}:{group_index}:{handler_index}"
+
+
+def hook_state_table(key: str) -> str:
+    """The TOML table header for one trust record (the key is always quoted)."""
+    return f'hooks.state."{key}"'
+
+
+def trust_records(hooks_json: Path | str, hooks_doc: dict, *, only_commands: set[str] | None = None) -> dict[str, str]:
+    """``{state_key: trusted_hash}`` for every command hook in a hooks.json document.
+
+    ``only_commands`` restricts the result to handlers whose command is in the
+    set -- the installer trusts what it wrote and nothing else.
+    """
+    out: dict[str, str] = {}
+    for event, groups in (hooks_doc.get("hooks") or {}).items():
+        if event not in EVENT_LABELS or not isinstance(groups, list):
+            continue
+        for gi, group in enumerate(groups):
+            if not isinstance(group, dict):
+                continue
+            matcher = group.get("matcher")
+            for hi, handler in enumerate(group.get("hooks") or []):
+                if not isinstance(handler, dict) or handler.get("type", "command") != "command":
+                    continue
+                if only_commands is not None and handler.get("command") not in only_commands:
+                    continue
+                out[hook_state_key(hooks_json, event, gi, hi)] = hook_trust_hash(event, handler, matcher)
+    return out
+
+
+# ── config.toml text surgery ────────────────────────────────────────────────
+# Codex users hand-edit config.toml; never rewrite the file, only insert or
+# replace the one table we own. tomllib reads, regex writes.
+
+_TABLE_RE_TEMPLATE = r'^\[{header}\]\n(?:(?!\[).*\n?)*'
+
+
+def _table_pattern(header_literal: str) -> re.Pattern:
+    return re.compile(_TABLE_RE_TEMPLATE.format(header=re.escape(header_literal)), re.MULTILINE)
+
+
+def upsert_toml_table(text: str, header_literal: str, body: str) -> str:
+    """Replace the table ``[header_literal]`` (header text exactly as it
+    appears between the brackets) or append it. Body lines are written as
+    given; the caller quotes values."""
+    block = f"[{header_literal}]\n{body.rstrip()}\n"
+    pat = _table_pattern(header_literal)
+    if pat.search(text):
+        return pat.sub(lambda _m: block + "\n", text, count=1).rstrip("\n") + "\n"
+    if not text.strip():
+        return block
+    sep = "" if text.endswith("\n") else "\n"
+    return f"{text}{sep}\n{block}"
+
+
+def remove_toml_table(text: str, header_literal: str) -> str:
+    pat = _table_pattern(header_literal)
+    return pat.sub("", text, count=1)
+
+
+def toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)  # JSON string escaping is valid TOML basic-string escaping
+
+
+def mcp_table_body(command: str, args: list[str]) -> str:
+    return f"command = {toml_string(command)}\nargs = [{', '.join(toml_string(a) for a in args)}]"
+
+
+def tool_table(tool: str) -> str:
+    return f"{MCP_TABLE}.tools.{tool}"
+
+
+def approved_tools() -> tuple[str, ...]:
+    """APPROVED_TOOLS filtered to what the active tool surface registers."""
+    try:
+        from llm_router.tool_surface import registered_tools
+        reg = registered_tools()
+    except Exception:  # noqa: BLE001
+        reg = None
+    if reg is None:
+        return APPROVED_TOOLS
+    return tuple(t for t in APPROVED_TOOLS if t in reg)
+
+
+def read_mcp_server(config_toml_text: str) -> dict | None:
+    """The ``[mcp_servers.llm_router]`` table as a dict, or None."""
+    import tomllib
+    try:
+        data = tomllib.loads(config_toml_text)
+    except tomllib.TOMLDecodeError:
+        return None
+    entry = (data.get("mcp_servers") or {}).get(MCP_SERVER_NAME)
+    return dict(entry) if isinstance(entry, dict) else None
+
+
+def read_trust_records(config_toml_text: str) -> dict[str, str]:
+    import tomllib
+    try:
+        data = tomllib.loads(config_toml_text)
+    except tomllib.TOMLDecodeError:
+        return {}
+    state = ((data.get("hooks") or {}).get("state") or {})
+    return {k: v.get("trusted_hash") for k, v in state.items() if isinstance(v, dict) and v.get("trusted_hash")}
+
+
+# ── AGENTS.md marked block ──────────────────────────────────────────────────
+
+def upsert_marked_block(text: str, body: str) -> str:
+    """Insert or replace the llm-router block in an AGENTS.md. Everything
+    outside the markers is preserved byte for byte."""
+    block = f"{AGENTS_BLOCK_START}\n{body.strip()}\n{AGENTS_BLOCK_END}\n"
+    pat = re.compile(re.escape(AGENTS_BLOCK_START) + r".*?" + re.escape(AGENTS_BLOCK_END) + r"\n?", re.DOTALL)
+    if pat.search(text):
+        return pat.sub(lambda _m: block, text, count=1)
+    if not text.strip():
+        return block
+    sep = "" if text.endswith("\n") else "\n"
+    return f"{text}{sep}\n{block}"
+
+
+def remove_marked_block(text: str) -> str:
+    pat = re.compile(r"\n*" + re.escape(AGENTS_BLOCK_START) + r".*?" + re.escape(AGENTS_BLOCK_END) + r"\n?", re.DOTALL)
+    out = pat.sub("\n", text, count=1)
+    out = re.sub(r"\n{3,}", "\n\n", out).strip("\n")
+    return out + "\n" if out else ""

--- a/src/llm_router/commands/doctor.py
+++ b/src/llm_router/commands/doctor.py
@@ -99,6 +99,151 @@ def _extract_toml_section_string(text: str, section: str, key: str) -> str | Non
     return _extract_toml_string(section_text, key)
 
 
+def _codex_checks() -> tuple[list[str], list[str]]:
+    """(report lines, issues) for the Codex CLI wiring.
+
+    Checks what Codex actually reads: `[mcp_servers.llm_router]` in
+    config.toml with a runnable command, `codex mcp list` agreeing, and every
+    llm_router hook in hooks.json carrying a matching trust record (Codex
+    skips an untrusted hook silently, so a hook without one is a failure,
+    not a warning). Legacy config.yaml / config.json entries are reported as
+    ignored. The opt-in gateway provider table is informational only.
+    """
+    from llm_router import codex_host
+
+    lines: list[str] = []
+    issues: list[str] = []
+    codex_dir = Path.home() / ".codex"
+    config_toml = codex_dir / "config.toml"
+    hooks_json = codex_dir / "hooks.json"
+    fix = "llm-router install"
+
+    text = ""
+    if config_toml.exists():
+        try:
+            text = config_toml.read_text()
+        except OSError as e:
+            lines.append(_fail(f"could not read {config_toml}: {e}"))
+            issues.append("Codex config.toml unreadable")
+            return lines, issues
+    else:
+        lines.append(_fail(f"config.toml not found at {config_toml}", fix=fix))
+        issues.append("Codex config.toml missing")
+        return lines, issues
+
+    # 1. MCP server
+    entry = codex_host.read_mcp_server(text)
+    if entry is None:
+        lines.append(_fail("[mcp_servers.llm_router] missing from config.toml — Codex cannot see llm-router", fix=fix))
+        issues.append("Codex MCP server not registered")
+    else:
+        problems = _mcp_command_problems(entry, "Codex")
+        if problems:
+            for p in problems:
+                lines.append(_fail(p, fix=fix))
+            issues.append("Codex MCP command cannot start")
+        else:
+            lines.append(_ok(f"MCP server registered in config.toml ({entry.get('command')})"))
+            tools = entry.get("tools") if isinstance(entry.get("tools"), dict) else {}
+            door = (tools.get("llm") or {}).get("approval_mode")
+            if door != "approve" and entry.get("default_tools_approval_mode") != "approve":
+                lines.append(_warn(
+                    "the `llm` tool is not auto-approved — `codex exec` (approval policy never) "
+                    "fails every routed call with 'requires approval'", ))
+                lines.append(_dim(f"    fix: {fix}"))
+
+    # 2. Codex's own view
+    binary = shutil.which("codex")
+    if binary and entry is not None:
+        try:
+            proc = subprocess.run(
+                [binary, "mcp", "list"], capture_output=True, text=True, timeout=5, check=False,
+                env={**os.environ, "CODEX_HOME": str(codex_dir)},
+            )
+            listed = "llm_router" in (proc.stdout or "")
+        except (OSError, subprocess.SubprocessError):
+            listed = None
+        if listed is True:
+            lines.append(_ok("`codex mcp list` shows llm_router"))
+        elif listed is False:
+            lines.append(_fail("`codex mcp list` does not show llm_router", fix=fix))
+            issues.append("codex mcp list missing llm_router")
+        else:
+            lines.append(_warn("`codex mcp list` did not answer in 5 s — skipped"))
+    elif not binary:
+        lines.append(_dim("    codex binary not on PATH — skipped `codex mcp list`"))
+
+    # 3. Hooks + trust
+    ours = str(Path.home() / ".llm-router" / "hooks")
+    if hooks_json.exists():
+        try:
+            doc = json.loads(hooks_json.read_text())
+        except (OSError, ValueError):
+            doc = None
+        if doc is None:
+            lines.append(_warn(f"{hooks_json} is not valid JSON — hooks disabled"))
+        else:
+            wanted = {}
+            for event, groups in (doc.get("hooks") or {}).items():
+                if event not in codex_host.EVENT_LABELS or not isinstance(groups, list):
+                    continue
+                for gi, g in enumerate(groups):
+                    for hi, hnd in enumerate((g.get("hooks") or []) if isinstance(g, dict) else []):
+                        if isinstance(hnd, dict) and ours in str(hnd.get("command", "")):
+                            key = codex_host.hook_state_key(hooks_json, event, gi, hi)
+                            wanted[key] = (event, codex_host.hook_trust_hash(event, hnd, g.get("matcher")))
+            have = codex_host.read_trust_records(text)
+            if not wanted:
+                lines.append(_warn("no llm_router hook in hooks.json — Codex gets pull routing only (no ⚡ ROUTE hint)"))
+            for key, (event, digest) in wanted.items():
+                if have.get(key) == digest:
+                    lines.append(_ok(f"{event} hook trusted"))
+                elif key in have:
+                    lines.append(_fail(f"{event} hook trust record is stale — Codex skips it silently", fix=fix))
+                    issues.append(f"Codex {event} hook untrusted (modified)")
+                else:
+                    lines.append(_fail(f"{event} hook has no trust record — Codex skips it silently", fix=fix))
+                    issues.append(f"Codex {event} hook untrusted")
+    else:
+        lines.append(_warn("hooks.json not found — Codex gets pull routing only (no ⚡ ROUTE hint)"))
+
+    # 4. AGENTS.md
+    agents = codex_dir / "AGENTS.md"
+    try:
+        has_block = agents.exists() and codex_host.AGENTS_BLOCK_START in agents.read_text()
+    except OSError:
+        has_block = False
+    lines.append(_ok("routing rules block in AGENTS.md") if has_block
+                 else _warn("no routing rules block in AGENTS.md", ))
+
+    # 5. Gateway (opt-in) and the one setting that breaks Codex
+    if _extract_toml_string(text, "model_provider") == "llm_router":
+        lines.append(_fail(
+            "Codex model_provider is force-set to 'llm_router' — this breaks Codex CLI "
+            "(gateway wire-format mismatch)", fix=fix,
+        ))
+        issues.append("Codex model_provider forced to llm_router (breaks Codex)")
+    if "[model_providers.llm_router]" in text:
+        lines.append(_dim("    opt-in gateway provider registered (use -c model_provider=llm_router per call)"))
+
+    # 6. Legacy leftovers
+    for legacy in ("config.yaml", "config.json", "rules/llm_router.md", "instructions.md"):
+        p = codex_dir / legacy
+        try:
+            if p.exists() and "llm_router" in p.read_text(errors="ignore"):
+                lines.append(_warn(f"{legacy} mentions llm_router but Codex never reads it — re-run install to clean up"))
+        except OSError:
+            pass
+
+    return lines, issues
+
+
+def _codex_report(issues: list[str]) -> list[str]:
+    lines, found = _codex_checks()
+    issues.extend(found)
+    return lines
+
+
 def _run_doctor_host(host: str) -> None:
     """Run host-specific installation checks."""
     valid_hosts = {"claude", "vscode", "cursor", "codex", "all"}
@@ -221,81 +366,8 @@ def _run_doctor_host(host: str) -> None:
                 print(_warn(f"routing rules not found at {cursor_rules}"))
 
         elif h == "codex":
-            codex_dir = Path.home() / ".codex"
-            config_toml = codex_dir / "config.toml"
-            config_yaml = codex_dir / "config.yaml"
-            hooks_json = codex_dir / "hooks.json"
-
-            gateway_url = None
-            if config_toml.exists():
-                try:
-                    text = config_toml.read_text()
-                    model_provider = _extract_toml_string(text, "model_provider")
-                    if model_provider == "llm_router":
-                        # The LLM Router gateway doesn't yet speak Codex's exact
-                        # OpenAI "responses" wire shape — forcing it as the
-                        # global default breaks EVERY Codex call (interactive
-                        # and LLM Router's own routed dispatch alike) with an
-                        # undecodable-stream error. An older llm_router install
-                        # set this; re-running the installer self-heals it.
-                        print(_fail(
-                            "Codex model_provider is force-set to 'llm_router' — "
-                            "this breaks Codex CLI (gateway wire-format mismatch)",
-                            fix="llm-router install --host codex --mode gateway",
-                        ))
-                        issues.append("Codex model_provider forced to llm_router (breaks Codex)")
-                    else:
-                        print(_ok(f"Codex using its own default model provider ({config_toml})"))
-
-                    if "[model_providers.llm_router]" in text:
-                        print(_ok("LLM Router model provider registered (available via -c model_provider=llm_router)"))
-                        gateway_url = _extract_toml_section_string(
-                            text, "model_providers.llm_router", "base_url"
-                        )
-                    else:
-                        print(_fail(
-                            "LLM Router model provider table missing",
-                            fix="llm-router install --host codex --mode gateway",
-                        ))
-                        issues.append("Codex LLM Router provider table missing")
-                except OSError as e:
-                    print(_fail(f"could not read {config_toml}: {e}"))
-                    issues.append("Codex config.toml unreadable")
-            else:
-                print(_fail(
-                    f"config.toml not found at {config_toml}",
-                    fix="llm-router install --host codex --mode gateway",
-                ))
-                issues.append("Codex config.toml missing")
-
-            if config_yaml.exists() and "llm_router" in config_yaml.read_text(errors="ignore"):
-                print(_ok("MCP companion registered in config.yaml"))
-            else:
-                print(_warn("MCP companion not found in config.yaml"))
-
-            if hooks_json.exists() and "codex-post-tool.py" in hooks_json.read_text(errors="ignore"):
-                print(_ok("PostToolUse telemetry hook installed"))
-            else:
-                print(_warn("PostToolUse telemetry hook not found"))
-
-            if gateway_url:
-                health_url = gateway_url.rstrip("/").removesuffix("/v1") + "/healthz"
-                try:
-                    req = urllib.request.Request(health_url, method="GET")
-                    with urllib.request.urlopen(req, timeout=2) as resp:
-                        data = json.loads(resp.read())
-                    if data.get("ok"):
-                        print(_ok(f"gateway reachable ({health_url})"))
-                        print(_green("  Opt-in routing (-c model_provider=llm_router): available"))
-                    else:
-                        print(_warn(f"gateway responded without ok=true ({health_url})"))
-                        print(_yellow("  Opt-in routing: registered, gateway health uncertain"))
-                except Exception as e:
-                    print(_warn(f"gateway not reachable at {health_url}: {e}"))
-                    print(_yellow("  Opt-in routing: registered, but gateway is not running"))
-
-        if not issues:
-            print(_green(f"  ✓ {h} is correctly configured"))
+            for line in _codex_report(issues):
+                print(f"  {line}")
         else:
             print(_red(f"  {len(issues)} issue(s) found for {h}"))
 
@@ -939,6 +1011,20 @@ def _run_doctor(host: Optional[str] = None) -> tuple[int, list[str]]:
         issues.append("MCP server not registered in Claude Code")
 
     # ── 4. Claude Desktop ──────────────────────────────────────────────────
+    # ── 4b. Codex CLI (only when installed) ──────────────────────────────────
+    # A present host with no registration is a FAIL: the user installed
+    # llm-router expecting both hosts wired, and a one-way install looks
+    # identical from inside Claude Code.
+    try:
+        from llm_router.host_detect import detect_hosts as _detect_hosts
+        _codex_present = _detect_hosts()["codex"].present
+    except Exception:  # noqa: BLE001
+        _codex_present = False
+    if _codex_present:
+        print(f"\n{_bold('  Codex CLI')}")
+        for line in _codex_report(issues):
+            print(f"  {line}")
+
     print(f"\n{_bold('  Claude Desktop')}")
     desktop_path = claude_desktop_config_path()
     if desktop_path is None:

--- a/src/llm_router/commands/install.py
+++ b/src/llm_router/commands/install.py
@@ -89,7 +89,7 @@ def _run_install(flags: list[str]) -> None:
     if "--host" in flags:
         idx = flags.index("--host")
         raw_host = (flags[idx + 1] if idx + 1 < len(flags) else "all").strip().lower()
-        mode = "gateway" if raw_host == "codex" else "auto"
+        mode = "auto"
         if "--mode" in flags:
             mode_idx = flags.index("--mode")
             mode = (flags[mode_idx + 1] if mode_idx + 1 < len(flags) else mode).strip().lower()
@@ -208,8 +208,35 @@ def _run_install(flags: list[str]) -> None:
             marker = _green('✓') if ok else _yellow('⚠')
             print(f"  {marker}  {a}")
 
+    # ── Other hosts on this machine (auto-detect) ──────────────────────────
+    # A user with Claude Code AND Codex wants both wired, both ways, from the
+    # one command. --host still targets a single host; --no-hosts skips this.
+    installed_hosts = ["Claude Code"]
+    if "--no-hosts" not in flags:
+        from llm_router.host_detect import detect_hosts
+        hosts = detect_hosts()
+        if hosts["codex"].present:
+            print(f"\n{_bold('  Codex CLI detected — installing...')}")
+            for a in _install_codex_files():
+                ok = a.lstrip().startswith("✓")
+                print(f"  {_green('✓') if ok else _dim('·')}  {a.lstrip('✓ ').strip()}")
+            installed_hosts.append("Codex CLI")
+
+    # ── Seats: which subscriptions are logged in (drives the free bucket) ──
+    try:
+        from llm_router import seats as _seats
+        _found = _seats.refresh_seats()
+        print(f"\n{_bold('  Seats')}  {_found.summary_line()}")
+        _bucket = sorted(_found.free_bucket())
+        if _bucket:
+            print(f"  free bucket: {', '.join(_bucket)}")
+        else:
+            print(_yellow("  no seat found — routed calls will bill an API key; log in to Claude Code, Codex, or start Ollama"))
+    except Exception:  # noqa: BLE001 -- install must not fail on a probe
+        pass
+
     print(f"\n{_green('✓')} {_bold('LLM Router installed globally.')}")
-    print("  Every Claude Code session will now auto-route tasks.")
+    print(f"  Every {' and '.join(installed_hosts)} session will now auto-route tasks.")
     print("  Restart Claude Code (and Claude Desktop if installed) to activate.\n")
 
     print(_bold("  Provider keys (optional — router works without any):"))
@@ -302,22 +329,14 @@ _SNIPPET_TOOLS = {
 
 _HOST_SNIPPETS: dict[str, str] = {
     "codex": """\
-{bold}Codex CLI{reset}  (capability extension — no cost-routing)
+{bold}Codex CLI{reset}  (MCP server + push-routing hook + AGENTS.md rules)
 ──────────────────────────────────────────────────────────────────
-1. Add to ~/.codex/config.yaml:
-
-   mcp:
-     servers:
-       llm_router:
-         command: llm-router
-         args: []
-
-2. Copy routing rules so Codex knows when to call llm_auto:
-
-   cp "$(python3 -c "import llm_router; import pathlib; print(pathlib.Path(llm_router.__file__).parent / 'rules' / 'codex-rules.md')")" \\
-      ~/.codex/instructions.md
-
-3. Restart Codex — run {savings_tool} to verify the DB is shared.
+Writes, in ~/.codex:
+  config.toml  [mcp_servers.llm_router] and the hook trust records
+  hooks.json   UserPromptSubmit -> auto-route (the ⚡ ROUTE hint), PostToolUse -> telemetry
+  AGENTS.md    a marked block of routing rules (replaced on re-run)
+Legacy config.yaml / config.json / rules/llm_router.md entries are removed: Codex never read them.
+Restart Codex, then run {savings_tool} to verify the DB is shared.
 """,
 
     "desktop": """\
@@ -522,122 +541,281 @@ def _install_codex_gateway_config(codex_dir) -> list[str]:
     return actions
 
 
-def _install_codex_files(mode: str = "gateway") -> list[str]:
-    """Write Codex-specific config files and return a list of actions taken."""
+# ── Codex CLI ───────────────────────────────────────────────────────────────
+#
+# One writer, targeting what Codex actually reads (verified against Codex
+# 0.153, 2026-09-04 -- see llm_router.codex_host):
+#
+#   ~/.codex/config.toml   [mcp_servers.llm_router]         the MCP server
+#                          [hooks.state."…"] trusted_hash   without this Codex
+#                                                           silently skips a hook
+#   ~/.codex/hooks.json    UserPromptSubmit -> auto-route   push routing, same
+#                          PostToolUse      -> telemetry    hint Claude Code gets
+#   ~/.codex/AGENTS.md     marked block of routing rules    Codex reads AGENTS.md
+#
+# Earlier versions wrote config.yaml, config.json, rules/llm_router.md and
+# instructions.md. Codex reads none of them, so Codex -> llm-router never
+# worked for anyone. Those are cleaned up below when they are ours.
+
+_CODEX_LEGACY_YAML_BLOCK = (
+    "\nmcp:\n"
+    "  servers:\n"
+    "    llm_router:\n"
+    "      command: llm-router\n"
+    "      args: []\n"
+)
+def _codex_hook_command(dst) -> str:
+    from llm_router.install_hooks import _python_exe
+    return f"{_python_exe()} {dst}"
+
+
+def _install_codex_files(mode: str = "mcp") -> list[str]:
+    """Write Codex-specific config files and return a list of actions taken.
+
+    ``mode``: "mcp" (default) registers the MCP server, hooks and rules.
+    "gateway" additionally registers the opt-in model provider table; it is
+    never the default because the gateway does not yet speak Codex's wire
+    format (see _install_codex_gateway_config).
+    """
+    import json as _json
     import pathlib
     import shutil as _shutil
 
+    from llm_router import codex_host, install_manifest
+    from llm_router.install_hooks import _build_mcp_entry, _localized_rules_text
+
     actions: list[str] = []
     home = pathlib.Path.home()
-
-    # 1. MCP server entry in ~/.codex/config.yaml
     codex_dir = home / ".codex"
     codex_dir.mkdir(parents=True, exist_ok=True)
-    config_yaml = codex_dir / "config.yaml"
-
-    mcp_block = (
-        "\nmcp:\n"
-        "  servers:\n"
-        "    llm_router:\n"
-        "      command: llm-router\n"
-        "      args: []\n"
-    )
-    existing = config_yaml.read_text() if config_yaml.exists() else ""
-    if "llm_router" not in existing:
-        with config_yaml.open("a") as f:
-            f.write(mcp_block)
-        actions.append(f"✓ Added llm_router MCP server to {config_yaml}")
-        try:
-            from llm_router import install_manifest
-            install_manifest.record("text_block", config_yaml, block=mcp_block)
-        except Exception:
-            pass
-    else:
-        actions.append(f"  llm_router already in {config_yaml} (skipped)")
-
-    # 2. PostToolUse hook in ~/.codex/hooks.json
+    config_toml = codex_dir / "config.toml"
     hooks_json = codex_dir / "hooks.json"
-    hook_script = home / ".llm-router" / "hooks" / "codex-post-tool.py"
+    agents_md = codex_dir / "AGENTS.md"
 
-    # Copy the hook script to ~/.llm-router/hooks/
-    hook_script.parent.mkdir(parents=True, exist_ok=True)
-    src_hook = pathlib.Path(__file__).parent.parent / "hooks" / "codex-post-tool.py"
-    if src_hook.exists():
-        _shutil.copy2(src_hook, hook_script)
-        hook_script.chmod(0o755)
-        actions.append(f"✓ Installed hook script to {hook_script}")
-        try:
-            from llm_router import install_manifest
-            install_manifest.record("file", hook_script)
-        except Exception:
-            pass
+    original = config_toml.read_text() if config_toml.exists() else ""
+    text = original
 
-    hook_entry = {
-        "hooks": {
-            "PostToolUse": [
-                {
-                    "matcher": "Bash",
-                    "hooks": [{"type": "command", "command": str(hook_script)}],
-                }
-            ]
-        }
-    }
+    # 1. MCP server ----------------------------------------------------------
+    # Surgical TOML insert, not `codex mcp add`: the CLI rewrites the whole
+    # file (re-orders the user's tables, drops blank lines and `args = []`).
+    # Codex users hand-edit config.toml; we own one table and the per-tool
+    # approval tables under it, nothing else.
+    entry, warnings = _build_mcp_entry()
+    if entry is None:
+        actions.extend(f"  {w}" for w in warnings)
+    else:
+        command, args = entry["command"], list(entry.get("args") or [])
+        text = codex_host.upsert_toml_table(
+            text, codex_host.MCP_TABLE, codex_host.mcp_table_body(command, args),
+        )
+        install_manifest.record("toml_table", config_toml, header=codex_host.MCP_TABLE)
+        # `codex exec` runs with approval policy "never": an MCP tool without
+        # approval_mode = "approve" fails with "MCP tool call requires
+        # approval" instead of routing. Approve the routing doors only; the
+        # admin / agent tools still prompt.
+        for tool in codex_host.approved_tools():
+            header = codex_host.tool_table(tool)
+            text = codex_host.upsert_toml_table(text, header, 'approval_mode = "approve"')
+            install_manifest.record("toml_table", config_toml, header=header)
+        actions.append(f"✓ Registered llm_router MCP server in {config_toml} ({command})")
+
+    # 2. Hooks ---------------------------------------------------------------
+    hooks_dir = home / ".llm-router" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    pkg_hooks = pathlib.Path(__file__).parent.parent / "hooks"
+    our_commands: set[str] = set()
+
+    route_dst = hooks_dir / "codex-auto-route.py"
+    route_src = pkg_hooks / "auto-route.py"
+    if route_src.exists():
+        _shutil.copy2(route_src, route_dst)
+        route_dst.chmod(0o755)
+        install_manifest.record("file", route_dst)
+        our_commands.add(_codex_hook_command(route_dst))
+        actions.append(f"✓ Installed auto-route hook to {route_dst}")
+    # The support module the hook falls back to when llm_router is not importable.
+    support_src = pathlib.Path(__file__).parent.parent / "tool_surface.py"
+    if support_src.exists():
+        _shutil.copy2(support_src, hooks_dir / "llm_router_tool_surface.py")
+        install_manifest.record("file", hooks_dir / "llm_router_tool_surface.py")
+
+    post_dst = hooks_dir / "codex-post-tool.py"
+    post_src = pkg_hooks / "codex-post-tool.py"
+    if post_src.exists():
+        _shutil.copy2(post_src, post_dst)
+        post_dst.chmod(0o755)
+        install_manifest.record("file", post_dst)
+        our_commands.add(str(post_dst))
+        actions.append(f"✓ Installed telemetry hook to {post_dst}")
+
+    doc: dict = {}
     if hooks_json.exists():
         try:
-            import json as _json
-            current = _json.loads(hooks_json.read_text())
-            existing_hooks = current.get("hooks", {}).get("PostToolUse", [])
-            already = any(
-                str(hook_script) in str(h)
-                for entry in existing_hooks
-                for h in entry.get("hooks", [])
-            )
-            if not already:
-                existing_hooks.append(hook_entry["hooks"]["PostToolUse"][0])
-                current.setdefault("hooks", {})["PostToolUse"] = existing_hooks
-                hooks_json.write_text(_json.dumps(current, indent=2))
-                actions.append(f"✓ Added PostToolUse hook to {hooks_json}")
-            else:
-                actions.append(f"  Hook already in {hooks_json} (skipped)")
-        except Exception as e:
-            actions.append(f"  Could not update {hooks_json}: {e}")
-    else:
-        import json as _json
-        hooks_json.write_text(_json.dumps(hook_entry, indent=2))
-        actions.append(f"✓ Created {hooks_json} with PostToolUse hook")
+            doc = _json.loads(hooks_json.read_text())
+        except (OSError, ValueError):
+            actions.append(f"  {hooks_json} is not valid JSON -- leaving it alone; hooks not installed")
+            doc = None
+    if doc is not None:
+        hooks = doc.setdefault("hooks", {})
+        changed = False
 
-    # 3. Copy routing rules to ~/.codex/instructions.md (append if exists)
-    instructions = codex_dir / "instructions.md"
+        def _ensure(event: str, matcher: str | None, cmd: str) -> None:
+            nonlocal changed
+            groups = hooks.setdefault(event, [])
+            for g in groups:
+                if any(h.get("command") == cmd for h in (g.get("hooks") or []) if isinstance(h, dict)):
+                    return
+            group: dict = {"hooks": [{"type": "command", "command": cmd}]}
+            if matcher is not None:
+                group["matcher"] = matcher
+            groups.append(group)
+            changed = True
+
+        if route_src.exists():
+            _ensure("UserPromptSubmit", None, _codex_hook_command(route_dst))
+        if post_src.exists():
+            _ensure("PostToolUse", "Bash", str(post_dst))
+        if changed or not hooks_json.exists():
+            hooks_json.write_text(_json.dumps(doc, indent=2) + "\n")
+            install_manifest.record("codex_hooks", hooks_json)
+            actions.append(f"✓ Registered hooks in {hooks_json}")
+        else:
+            actions.append(f"  Hooks already in {hooks_json} (skipped)")
+
+        # 3. Trust records -- the part every earlier version missed ---------
+        for key, digest in codex_host.trust_records(hooks_json, doc, only_commands=our_commands).items():
+            text = codex_host.upsert_toml_table(
+                text, codex_host.hook_state_table(key), f'trusted_hash = "{digest}"',
+            )
+            install_manifest.record("toml_table", config_toml, header=codex_host.hook_state_table(key))
+        if our_commands:
+            actions.append("✓ Trusted the hooks in config.toml (Codex skips untrusted hooks silently)")
+
+    # 4. Self-heal a forced global default from an old install ---------------
+    import re as _re
+    if _re.search(r'^model_provider\s*=\s*"llm_router"\s*$', text, _re.MULTILINE):
+        actions.append(
+            "✓ Reverted Codex's default model_provider (was force-set to 'llm_router' by an "
+            f"earlier install, which broke Codex CLI — see {config_toml})"
+        )
+    text = _remove_toml_scalar_if_equals(text, "model", "auto")
+    text = _remove_toml_scalar_if_equals(text, "model_provider", "llm_router")
+
+    if text != original:
+        try:
+            bak = codex_dir / "config.toml.llm_router-bak"
+            if config_toml.exists() and not bak.exists():
+                _shutil.copy2(config_toml, bak)
+                actions.append(f"✓ Backed up Codex config to {bak}")
+            config_toml.write_text(text)
+        except OSError as e:
+            actions.append(f"  Could not update {config_toml}: {e}")
+
+    # 5. AGENTS.md -----------------------------------------------------------
     rules_src = pathlib.Path(__file__).parent.parent / "rules" / "codex-rules.md"
     if rules_src.exists():
-        rules_text = rules_src.read_text()
-        if instructions.exists():
-            existing_inst = instructions.read_text()
-            if "llm_router" not in existing_inst:
-                block = f"\n\n{rules_text}"
-                with instructions.open("a") as f:
-                    f.write(block)
-                actions.append(f"✓ Appended routing rules to {instructions}")
-                try:
-                    from llm_router import install_manifest
-                    install_manifest.record("text_block", instructions, block=block)
-                except Exception:
-                    pass
-            else:
-                actions.append(f"  Routing rules already in {instructions} (skipped)")
+        rules_text = _localized_rules_text(rules_src)
+        existing = agents_md.read_text() if agents_md.exists() else ""
+        updated = codex_host.upsert_marked_block(existing, rules_text)
+        if updated != existing:
+            agents_md.write_text(updated)
+            actions.append(f"✓ Wrote routing rules block to {agents_md}")
         else:
-            instructions.write_text(rules_text)
-            actions.append(f"✓ Created {instructions} with routing rules")
-            try:
-                from llm_router import install_manifest
-                install_manifest.record("created_file", instructions, block=rules_text)
-            except Exception:
-                pass
+            actions.append(f"  Routing rules already current in {agents_md} (skipped)")
+        install_manifest.record("codex_agents_block", agents_md)
+
+    # 6. Legacy files Codex never read ---------------------------------------
+    actions.extend(_cleanup_codex_legacy(codex_dir))
 
     if mode == "gateway":
         actions += _install_codex_gateway_config(codex_dir)
-    elif mode not in {"companion", "mcp", "mcp-only", "rules", "auto"}:
-        actions.append(f"  Unknown Codex mode {mode!r}; installed MCP companion only")
+    elif mode not in {"mcp", "companion", "mcp-only", "rules", "auto"}:
+        actions.append(f"  Unknown Codex mode {mode!r}; installed MCP, hooks and rules only")
+
+    return actions
+
+
+def _cleanup_codex_legacy(codex_dir) -> list[str]:
+    """Remove what earlier installers wrote to files Codex does not read.
+
+    Only content that is recognisably ours is touched: the exact YAML block,
+    JSON entries whose command is ours, a rules file that starts with our
+    header, and an instructions.md block recorded in the manifest (or a file
+    that is nothing but our rules).
+    """
+    import json as _json
+    import pathlib
+
+    from llm_router import install_manifest
+
+    actions: list[str] = []
+    codex_dir = pathlib.Path(codex_dir)
+
+    yaml_path = codex_dir / "config.yaml"
+    if yaml_path.exists():
+        try:
+            y = yaml_path.read_text()
+            if _CODEX_LEGACY_YAML_BLOCK in y:
+                y = y.replace(_CODEX_LEGACY_YAML_BLOCK, "", 1)
+                if y.strip():
+                    yaml_path.write_text(y)
+                else:
+                    yaml_path.unlink()
+                actions.append(f"✓ Removed legacy MCP block from {yaml_path} (Codex never read it)")
+        except OSError:
+            pass
+
+    json_path = codex_dir / "config.json"
+    if json_path.exists():
+        try:
+            data = _json.loads(json_path.read_text())
+            servers = data.get("mcpServers") if isinstance(data, dict) else None
+            if isinstance(servers, dict):
+                removed = False
+                for name in ("llm_router", "llm-router"):
+                    ent = servers.get(name)
+                    if isinstance(ent, dict) and (
+                        ent.get("command") in ("llm-router", "llm_router")
+                        or "claude-code-llm-router" in (ent.get("args") or [])
+                    ):
+                        servers.pop(name)
+                        removed = True
+                if removed:
+                    if servers or len(data) > 1:
+                        json_path.write_text(_json.dumps(data, indent=2))
+                    else:
+                        json_path.unlink()
+                    actions.append(f"✓ Removed legacy MCP entry from {json_path} (Codex never read it)")
+        except (OSError, ValueError):
+            pass
+
+    rules_md = codex_dir / "rules" / "llm_router.md"
+    if rules_md.exists():
+        try:
+            if rules_md.read_text().lstrip().startswith("<!-- llm_router-rules-version"):
+                rules_md.unlink()
+                actions.append(f"✓ Removed legacy {rules_md} (Codex reads AGENTS.md, not rules/*.md)")
+        except OSError:
+            pass
+
+    instructions = codex_dir / "instructions.md"
+    if instructions.exists():
+        try:
+            rec = install_manifest.find("text_block", instructions)
+            created = install_manifest.find("created_file", instructions)
+            content = instructions.read_text()
+            if rec and rec.get("block") and rec["block"] in content:
+                remaining = content.replace(rec["block"], "", 1)
+                if remaining.strip():
+                    instructions.write_text(remaining)
+                else:
+                    instructions.unlink()
+                actions.append(f"✓ Removed legacy routing rules from {instructions}")
+            elif created and content.lstrip().startswith("<!-- llm_router-rules-version"):
+                instructions.unlink()
+                actions.append(f"✓ Removed legacy {instructions}")
+        except OSError:
+            pass
 
     return actions
 
@@ -1232,8 +1410,8 @@ def _install_host(host: str, mode: str = "auto") -> None:
 
     # Hosts that write files; all others print snippets
     _FILE_WRITERS = {
-        "codex":      (lambda: _install_codex_files(mode="gateway" if mode == "auto" else mode),
-                       "Restart Codex and run `llm-router doctor --host codex` to verify automatic routing."),
+        "codex":      (lambda: _install_codex_files(mode="mcp" if mode == "auto" else mode),
+                       "Restart Codex and run `llm-router doctor --host codex` to verify."),
         "opencode":   (_install_opencode_files,     f"Restart OpenCode and run {route_tool('llm_savings')} to verify."),
         "gemini-cli": (_install_gemini_cli_files,   f"Restart Gemini CLI and run {route_tool('llm_savings')} to verify."),
         "copilot-cli":(_install_copilot_cli_files,  f"Restart Copilot CLI and run {route_tool('llm_savings')} to verify."),

--- a/src/llm_router/hosts/events.py
+++ b/src/llm_router/hosts/events.py
@@ -111,17 +111,28 @@ CODEX = HostEvents(
         Event.SUBAGENT_STOP: "SubagentStop",
         Event.STOP: "Stop",
     },
-    # Payload keys NOT yet captured from a running Codex. Task 18 must record a
-    # real payload before reading any of these.
-    prompt_key=None,
-    session_key=None,
+    # UserPromptSubmit payload captured from a real `codex exec` run of Codex
+    # 0.153.2 on 2026-09-04 (tests/fixtures/codex_user_prompt_submit.json).
+    # Tool-event keys are still unverified: no PreToolUse payload has been
+    # captured, so a port must not read them yet.
+    prompt_key="prompt",
+    session_key="session_id",
     tool_name_key=None,
     tool_input_key=None,
     can_block_prompt=True,
     can_rewrite_tool_input=True,
     block_shape={"decision": "block", "reason": "<text>"},
-    context_key=None,
+    # codex-rs/hooks/src/schema.rs UserPromptSubmitHookSpecificOutputWire:
+    # {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit",
+    #  "additionalContext": "..."}} -- deny_unknown_fields, so nothing else.
+    context_key="hookSpecificOutput.additionalContext",
     notes=(
+        "A hook in hooks.json runs ONLY with a matching "
+        "[hooks.state.\"<hooks.json>:<event>:<group>:<handler>\"] trusted_hash "
+        "record in config.toml; otherwise Codex skips it silently. "
+        "llm_router.codex_host computes the hash.",
+        "The payload also carries turn_id, transcript_path, cwd, "
+        "hook_event_name, model (e.g. gpt-5.5) and permission_mode.",
         "Hooks are enabled by default; disabled via [features].hooks = false.",
         "PreToolUse can rewrite arguments via updatedInput — a capability the "
         "Claude Code path does not have, so the shared core must treat rewrite "

--- a/src/llm_router/install_manifest.py
+++ b/src/llm_router/install_manifest.py
@@ -195,6 +195,10 @@ def apply_uninstall() -> list[str]:
                 actions += _restore_json_key(
                     path, rec.get("key", ""), bool(rec.get("had_key")), rec.get("previous")
                 )
+            elif kind == "codex_hooks":
+                actions += _remove_codex_hooks(path)
+            elif kind == "codex_agents_block":
+                actions += _remove_codex_agents_block(path)
         except Exception as e:  # noqa: BLE001 — one bad record must not abort the rest
             _p = rec.get("path", "?")
             actions.append(f"  manifest removal skipped ({_p}): {e}")
@@ -250,3 +254,49 @@ def _remove_text_block(path: pathlib.Path, block: str) -> list[str]:
             path.unlink()
         return [f"✓ Removed llm_router block from {path}"]
     return []
+
+
+def _remove_codex_hooks(path: pathlib.Path) -> list[str]:
+    """Drop the hook groups whose command points into ~/.llm-router/hooks.
+    Everything else in the user's hooks.json is untouched."""
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return []
+    ours = str(pathlib.Path.home() / ".llm-router" / "hooks")
+    hooks = data.get("hooks") if isinstance(data, dict) else None
+    if not isinstance(hooks, dict):
+        return []
+    removed = 0
+    for event, groups in list(hooks.items()):
+        if not isinstance(groups, list):
+            continue
+        kept = []
+        for g in groups:
+            handlers = (g.get("hooks") or []) if isinstance(g, dict) else []
+            if any(isinstance(h, dict) and ours in str(h.get("command", "")) for h in handlers):
+                removed += 1
+            else:
+                kept.append(g)
+        hooks[event] = kept
+    if removed:
+        path.write_text(json.dumps(data, indent=2) + "\n")
+        return [f"✓ Removed {removed} llm_router hook group(s) from {path}"]
+    return []
+
+
+def _remove_codex_agents_block(path: pathlib.Path) -> list[str]:
+    if not path.exists():
+        return []
+    from llm_router import codex_host
+    text = path.read_text()
+    updated = codex_host.remove_marked_block(text)
+    if updated == text:
+        return []
+    if updated.strip():
+        path.write_text(updated)
+    else:
+        path.unlink()
+    return [f"✓ Removed llm_router block from {path}"]

--- a/tests/commands/test_doctor.py
+++ b/tests/commands/test_doctor.py
@@ -122,74 +122,73 @@ class TestRunDoctorHost:
             # Cursor may not be installed
             pass
 
-    def test_run_doctor_host_codex_gateway_reachable(self, capsys, tmp_path, monkeypatch):
-        """Codex doctor proves the llm_router provider is registered and reachable
-        for opt-in use, WITHOUT it being forced as Codex's global default —
-        forcing it breaks Codex CLI (gateway wire-format mismatch with
-        Codex's expected OpenAI "responses" shape)."""
+    def _codex_home(self, tmp_path, monkeypatch, toml: str, hooks: dict | None = None):
         monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("llm_router.commands.doctor.shutil.which", lambda name: None)
         codex = tmp_path / ".codex"
         codex.mkdir()
-        (codex / "config.toml").write_text(
-            '[model_providers.gemini]\n'
-            'base_url = "https://generativelanguage.googleapis.com/v1beta/openai"\n\n'
-            '[model_providers.llm_router]\n'
-            'base_url = "http://127.0.0.1:17900/v1"\n'
-            'wire_api = "responses"\n'
+        (codex / "config.toml").write_text(toml)
+        if hooks is not None:
+            import json as _json
+            (codex / "hooks.json").write_text(_json.dumps(hooks))
+        return codex
+
+    def test_run_doctor_host_codex_healthy(self, capsys, tmp_path, monkeypatch):
+        """Registered in config.toml with a runnable command, hooks trusted, rules present."""
+        from llm_router import codex_host
+        script = tmp_path / "llm-router"
+        script.write_text("#!/bin/sh\n")
+        script.chmod(0o755)
+        hook_cmd = f"/usr/bin/python3 {tmp_path}/.llm-router/hooks/codex-auto-route.py"
+        hooks = {"hooks": {"UserPromptSubmit": [{"hooks": [{"type": "command", "command": hook_cmd}]}]}}
+        key = codex_host.hook_state_key(tmp_path / ".codex" / "hooks.json", "UserPromptSubmit", 0, 0)
+        digest = codex_host.hook_trust_hash("UserPromptSubmit", {"type": "command", "command": hook_cmd})
+        toml = (
+            f'[mcp_servers.llm_router]\ncommand = "{script}"\nargs = []\n\n'
+            f'[mcp_servers.llm_router.tools.llm]\napproval_mode = "approve"\n\n'
+            f'[hooks.state."{key}"]\ntrusted_hash = "{digest}"\n'
         )
-        (codex / "config.yaml").write_text("mcp:\n  servers:\n    llm_router: {}\n")
-        (codex / "hooks.json").write_text("codex-post-tool.py\n")
+        codex = self._codex_home(tmp_path, monkeypatch, toml, hooks)
+        (codex / "AGENTS.md").write_text(f"{codex_host.AGENTS_BLOCK_START}\nx\n{codex_host.AGENTS_BLOCK_END}\n")
 
-        class _Resp:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_args):
-                return False
-
-            def read(self):
-                return b'{"ok": true}'
-
-        seen = {}
-
-        def _fake_urlopen(req, **_kwargs):
-            seen["url"] = req.full_url
-            return _Resp()
-
-        monkeypatch.setattr("llm_router.commands.doctor.urllib.request.urlopen", _fake_urlopen)
         _run_doctor_host("codex")
-        output = capsys.readouterr().out
-        assert "Codex using its own default model provider" in output
-        assert "LLM Router model provider registered" in output
-        assert "gateway reachable" in output
-        assert "Opt-in routing" in output
-        assert seen["url"] == "http://127.0.0.1:17900/healthz"
+        out = capsys.readouterr().out
+        assert "MCP server registered in config.toml" in out
+        assert "UserPromptSubmit hook trusted" in out
+        assert "routing rules block in AGENTS.md" in out
+        assert "✗" not in out
+
+    def test_run_doctor_host_codex_untrusted_hook_is_a_failure(self, capsys, tmp_path, monkeypatch):
+        """Codex silently skips an untrusted hook, so a missing or stale record must fail."""
+        from llm_router import codex_host
+        hook_cmd = f"/usr/bin/python3 {tmp_path}/.llm-router/hooks/codex-auto-route.py"
+        hooks = {"hooks": {"UserPromptSubmit": [{"hooks": [{"type": "command", "command": hook_cmd}]}]}}
+        key = codex_host.hook_state_key(tmp_path / ".codex" / "hooks.json", "UserPromptSubmit", 0, 0)
+        self._codex_home(tmp_path, monkeypatch, f'[hooks.state."{key}"]\ntrusted_hash = "sha256:stale"\n', hooks)
+        issues: list[str] = []
+        from llm_router.commands.doctor import _codex_report
+        lines = "\n".join(_codex_report(issues))
+        assert "trust record is stale" in lines
+        assert "[mcp_servers.llm_router] missing" in lines
+        assert any("untrusted" in i for i in issues) and any("not registered" in i for i in issues)
 
     def test_run_doctor_host_codex_reports_forced_default_as_broken(self, capsys, tmp_path, monkeypatch):
         """A config with model_provider forced to llm_router (left over from an
-        older llm_router install) must be flagged as broken, not healthy — it
-        breaks every Codex call via the gateway wire-format mismatch."""
-        monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
-        codex = tmp_path / ".codex"
-        codex.mkdir()
-        (codex / "config.toml").write_text('model = "auto"\nmodel_provider = "llm_router"\n')
-
+        older llm_router install) must be flagged as broken, not healthy."""
+        self._codex_home(tmp_path, monkeypatch, 'model = "auto"\nmodel_provider = "llm_router"\n')
         _run_doctor_host("codex")
         output = capsys.readouterr().out
         assert "force-set to 'llm_router'" in output
-        assert "llm-router install --host codex --mode gateway" in output
+        assert "llm-router install" in output
 
-    def test_run_doctor_host_codex_reports_not_gateway(self, capsys, tmp_path, monkeypatch):
-        monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
-        codex = tmp_path / ".codex"
-        codex.mkdir()
-        (codex / "config.toml").write_text('model = "gpt-5.5"\nmodel_provider = "openai"\n')
-
+    def test_run_doctor_host_codex_flags_legacy_files_codex_never_reads(self, capsys, tmp_path, monkeypatch):
+        codex = self._codex_home(tmp_path, monkeypatch, 'model = "gpt-5.5"\n')
+        (codex / "config.yaml").write_text("mcp:\n  servers:\n    llm_router: {}\n")
         _run_doctor_host("codex")
         output = capsys.readouterr().out
-        assert "Codex using its own default model provider" in output
-        assert "LLM Router model provider table missing" in output
-        assert "llm-router install --host codex --mode gateway" in output
+        assert "config.yaml mentions llm_router but Codex never reads it" in output
+        assert "[mcp_servers.llm_router] missing" in output
 
     def test_run_doctor_host_all(self, capsys):
         """Test doctor checks all hosts."""

--- a/tests/fixtures/codex_user_prompt_submit.json
+++ b/tests/fixtures/codex_user_prompt_submit.json
@@ -1,0 +1,10 @@
+{
+  "session_id": "01a06e3d-a1cc-7d41-927b-8ad26b5f69ec",
+  "turn_id": "01a06e3d-a247-77f1-a270-4a2cb877b4c2",
+  "transcript_path": "/Users/me/.codex/sessions/2026/09/04/rollout-2026-09-04T22-05-28-01a06e3d.jsonl",
+  "cwd": "/Users/me/project",
+  "hook_event_name": "UserPromptSubmit",
+  "model": "gpt-5.5",
+  "permission_mode": "bypassPermissions",
+  "prompt": "Reply with the single word: pong"
+}

--- a/tests/test_codex_gateway_install.py
+++ b/tests/test_codex_gateway_install.py
@@ -1,7 +1,9 @@
-"""Codex gateway install wiring.
+"""Codex gateway install wiring (opt-in mode).
 
-Codex automatic routing depends on routing the host model provider through the
-LLM Router OpenAI-compatible gateway, not only installing MCP pull-routing tools.
+The gateway does not yet speak Codex's "responses" wire shape, so it is never
+the default and must never be forced as Codex's global model provider. Since
+2026-09 the default Codex install is the MCP server + hooks + AGENTS.md
+(tests/test_codex_install.py); `--mode gateway` layers the provider table on top.
 """
 from __future__ import annotations
 
@@ -9,50 +11,40 @@ import contextlib
 import io
 import pathlib
 
-
 def _patch_home(monkeypatch, tmp_path):
     monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
 
 
 def test_codex_gateway_install_writes_provider_and_keeps_mcp(monkeypatch, tmp_path):
-    """The llm_router provider is registered (available for opt-in use) but must
-    NOT be forced as Codex's global default — the gateway doesn't yet speak
-    Codex's exact "responses" wire shape, so forcing it as default breaks
-    every Codex call (interactive and LLM Router's own routed dispatch alike)."""
+    from llm_router import codex_host
     from llm_router.commands.install import _install_codex_files
 
     _patch_home(monkeypatch, tmp_path)
     actions = _install_codex_files(mode="gateway")
 
     config_toml = tmp_path / ".codex" / "config.toml"
-    assert config_toml.exists()
     text = config_toml.read_text()
     assert 'model = "auto"' not in text
     assert 'model_provider = "llm_router"' not in text
     assert "[model_providers.llm_router]" in text
     assert 'base_url = "http://127.0.0.1:17900/v1"' in text
     assert 'wire_api = "responses"' in text
-
-    config_yaml = tmp_path / ".codex" / "config.yaml"
-    assert "llm_router" in config_yaml.read_text()
+    # the MCP server is in config.toml -- the file Codex reads -- not config.yaml
+    assert codex_host.read_mcp_server(text) is not None
+    assert not (tmp_path / ".codex" / "config.yaml").exists()
     assert any("Registered LLM Router as an available Codex model provider" in a for a in actions)
 
 
 def test_codex_gateway_install_self_heals_previously_forced_default(monkeypatch, tmp_path):
-    """A config left over from an earlier llm_router install that forced
-    model_provider=llm_router/model=auto must be reverted on the next install run
-    — this is what lets existing broken installs self-heal via a reinstall."""
     from llm_router.commands.install import _install_codex_files
 
     _patch_home(monkeypatch, tmp_path)
-    codex_dir = tmp_path / ".codex"
-    codex_dir.mkdir()
-    config_toml = codex_dir / "config.toml"
-    config_toml.write_text('model = "auto"\nmodel_provider = "llm_router"\n')
-
+    codex = tmp_path / ".codex"
+    codex.mkdir()
+    (codex / "config.toml").write_text('model = "auto"\nmodel_provider = "llm_router"\n')
     actions = _install_codex_files(mode="gateway")
-    text = config_toml.read_text()
+    text = (codex / "config.toml").read_text()
     assert 'model = "auto"' not in text
     assert 'model_provider = "llm_router"' not in text
     assert "[model_providers.llm_router]" in text
@@ -63,47 +55,45 @@ def test_codex_gateway_install_backs_up_existing_config_once(monkeypatch, tmp_pa
     from llm_router.commands.install import _install_codex_files
 
     _patch_home(monkeypatch, tmp_path)
-    codex_dir = tmp_path / ".codex"
-    codex_dir.mkdir()
-    config_toml = codex_dir / "config.toml"
-    config_toml.write_text('model = "gpt-5.5"\nmodel_provider = "openai"\n')
-
+    codex = tmp_path / ".codex"
+    codex.mkdir()
+    (codex / "config.toml").write_text('model = "gpt-5.5"\n')
     _install_codex_files(mode="gateway")
-    backup = codex_dir / "config.toml.llm_router-bak"
-    assert backup.exists()
-    assert 'model_provider = "openai"' in backup.read_text()
-
-    backup.write_text("sentinel\n")
+    bak = codex / "config.toml.llm_router-bak"
+    assert bak.read_text() == 'model = "gpt-5.5"\n'
     _install_codex_files(mode="gateway")
-    assert backup.read_text() == "sentinel\n"
+    assert bak.read_text() == 'model = "gpt-5.5"\n', "second run must not overwrite the backup"
 
 
-def test_codex_companion_mode_does_not_change_model_provider(monkeypatch, tmp_path):
+def test_default_mode_does_not_touch_model_provider(monkeypatch, tmp_path):
     from llm_router.commands.install import _install_codex_files
 
     _patch_home(monkeypatch, tmp_path)
-    codex_dir = tmp_path / ".codex"
-    codex_dir.mkdir()
-    config_toml = codex_dir / "config.toml"
-    config_toml.write_text('model = "gpt-5.5"\nmodel_provider = "openai"\n')
-
-    _install_codex_files(mode="companion")
-    text = config_toml.read_text()
-    assert 'model = "gpt-5.5"' in text
+    codex = tmp_path / ".codex"
+    codex.mkdir()
+    (codex / "config.toml").write_text('model_provider = "openai"\n')
+    _install_codex_files()
+    text = (codex / "config.toml").read_text()
     assert 'model_provider = "openai"' in text
-    assert "[model_providers.llm_router]" not in text
+    assert "[model_providers.llm_router]" not in text, "gateway is opt-in only"
 
 
-def test_run_install_host_codex_gateway_mode_uses_temp_home(monkeypatch, tmp_path):
+def test_run_install_host_codex_defaults_to_mcp_and_gateway_is_opt_in(monkeypatch, tmp_path):
     from llm_router.commands import install
 
     _patch_home(monkeypatch, tmp_path)
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
+        install._run_install(["--host", "codex"])
+    text = (tmp_path / ".codex" / "config.toml").read_text()
+    assert "[mcp_servers.llm_router]" in text
+    assert "[model_providers.llm_router]" not in text
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
         install._run_install(["--host", "codex", "--mode", "gateway"])
-
     out = buf.getvalue()
-    assert "Codex" in out
-    assert "model provider" in out
-    assert 'model_provider = "llm_router"' not in (tmp_path / ".codex" / "config.toml").read_text()
-
+    assert "Codex" in out and "model provider" in out
+    text = (tmp_path / ".codex" / "config.toml").read_text()
+    assert "[model_providers.llm_router]" in text
+    assert 'model_provider = "llm_router"' not in text

--- a/tests/test_codex_hook_payload.py
+++ b/tests/test_codex_hook_payload.py
@@ -1,0 +1,32 @@
+"""The Codex UserPromptSubmit payload, captured from a real run, agrees with events.py."""
+from __future__ import annotations
+
+import json
+import pathlib
+
+from llm_router.hosts import events
+
+FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "codex_user_prompt_submit.json"
+
+
+def test_verified_keys_exist_in_the_real_payload():
+    payload = json.loads(FIXTURE.read_text())
+    spec = events.HOSTS["codex"]
+    assert payload[spec.prompt_key] == "Reply with the single word: pong"
+    assert payload[spec.session_key].startswith("01a06e3d")
+    assert payload["hook_event_name"] == "UserPromptSubmit"
+
+
+def test_tool_keys_remain_honestly_unverified():
+    assert set(events.unverified_fields("codex")) == {"tool_name_key", "tool_input_key"}
+    assert events.routing_ready("codex") is False, "no PreToolUse payload captured yet"
+
+
+def test_auto_route_can_tell_a_codex_session_from_the_model_field():
+    """auto-route.py keys platform detection off `model`; the real payload carries it."""
+    import importlib.util
+    path = pathlib.Path(events.__file__).resolve().parents[1] / "hooks" / "auto-route.py"
+    spec = importlib.util.spec_from_file_location("llm_router_auto_route_hook", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert mod._is_codex_session(json.loads(FIXTURE.read_text())) is True

--- a/tests/test_codex_host.py
+++ b/tests/test_codex_host.py
@@ -1,0 +1,140 @@
+"""Codex-specific pure helpers: trust hash, state keys, TOML and AGENTS.md surgery."""
+from __future__ import annotations
+
+import pytest
+
+from llm_router import codex_host as C
+
+# Captured 2026-09-04: with exactly this record in config.toml, Codex 0.153.2 ran the
+# hook; without it the hook was silently skipped. Pins the recipe end to end.
+GOLDEN_CMD = "/private/tmp/claude-501/-Users-yaliandrona/aafedb09-c181-4dcc-8615-1a3f442a817f/scratchpad/dump_hook.sh"
+GOLDEN_HASH = "sha256:e370c6859c4e6f39a52fdb18d2524fa9d67815369422717a1e7b6dcb65337497"
+
+
+def test_trust_hash_matches_what_codex_accepted():
+    assert C.hook_trust_hash("UserPromptSubmit", {"type": "command", "command": GOLDEN_CMD}) == GOLDEN_HASH
+
+
+def test_user_prompt_submit_drops_the_matcher_before_hashing():
+    """Codex normalizes the matcher to None for UserPromptSubmit/Stop, so a
+    hooks.json that says matcher "" hashes identically to one that omits it."""
+    h = {"type": "command", "command": GOLDEN_CMD}
+    assert C.hook_trust_hash("UserPromptSubmit", h, matcher="") == GOLDEN_HASH
+    assert C.hook_trust_hash("UserPromptSubmit", h, matcher="Bash") == GOLDEN_HASH
+
+
+def test_tool_events_keep_the_matcher():
+    h = {"type": "command", "command": "/x"}
+    assert C.hook_trust_hash("PostToolUse", h, matcher="Bash") != C.hook_trust_hash("PostToolUse", h, matcher=None)
+
+
+def test_default_timeout_is_600_and_explicit_600_is_identical():
+    h = {"type": "command", "command": "/x"}
+    assert C.hook_trust_hash("UserPromptSubmit", h) == C.hook_trust_hash("UserPromptSubmit", {**h, "timeout": 600})
+    assert C.hook_trust_hash("UserPromptSubmit", h) != C.hook_trust_hash("UserPromptSubmit", {**h, "timeout": 30})
+
+
+def test_optional_fields_only_enter_when_set():
+    h = {"type": "command", "command": "/x"}
+    base = C.hook_trust_hash("UserPromptSubmit", h)
+    assert C.hook_trust_hash("UserPromptSubmit", {**h, "async": False}) == base
+    assert C.hook_trust_hash("UserPromptSubmit", {**h, "async": True}) != base
+    assert C.hook_trust_hash("UserPromptSubmit", {**h, "additionalContextLimit": 2500}) == base
+    assert C.hook_trust_hash("UserPromptSubmit", {**h, "additionalContextLimit": 100}) != base
+    assert C.hook_trust_hash("UserPromptSubmit", {**h, "statusMessage": "hi"}) != base
+
+
+def test_unknown_event_or_non_command_rejected():
+    with pytest.raises(ValueError):
+        C.hook_trust_hash("Nope", {"type": "command", "command": "/x"})
+    with pytest.raises(ValueError):
+        C.hook_trust_hash("Stop", {"type": "mcp_tool", "server": "s", "tool": "t"})
+
+
+def test_state_key_format():
+    assert C.hook_state_key("/h/.codex/hooks.json", "UserPromptSubmit", 0, 1) == "/h/.codex/hooks.json:user_prompt_submit:0:1"
+    assert C.hook_state_table("a:b:0:0") == 'hooks.state."a:b:0:0"'
+
+
+def test_trust_records_walk_every_command_hook_and_can_be_restricted():
+    doc = {"hooks": {
+        "PostToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "/theirs"}]}],
+        "UserPromptSubmit": [
+            {"hooks": [{"type": "mcp_tool", "server": "s", "tool": "t"}]},
+            {"hooks": [{"type": "command", "command": GOLDEN_CMD}]},
+        ],
+        "Bogus": [{"hooks": [{"type": "command", "command": "/x"}]}],
+    }}
+    recs = C.trust_records("/h/hooks.json", doc)
+    assert recs["/h/hooks.json:user_prompt_submit:1:0"] == GOLDEN_HASH
+    assert "/h/hooks.json:post_tool_use:0:0" in recs
+    assert len(recs) == 2
+    mine = C.trust_records("/h/hooks.json", doc, only_commands={GOLDEN_CMD})
+    assert list(mine) == ["/h/hooks.json:user_prompt_submit:1:0"]
+
+
+# ── TOML surgery ───────────────────────────────────────────────────────────
+
+USER_TOML = (
+    '# my config\nmodel = "gpt-5.5"\n\n'
+    '[model_providers.gemini]\nname = "Gemini"\n\n'
+    '[projects."/Users/me"]\ntrust_level = "trusted"\n'
+)
+
+
+def test_upsert_appends_table_and_preserves_user_text():
+    out = C.upsert_toml_table(USER_TOML, C.MCP_TABLE, C.mcp_table_body("/bin/llm-router", []))
+    assert out.startswith(USER_TOML)
+    assert out.endswith('[mcp_servers.llm_router]\ncommand = "/bin/llm-router"\nargs = []\n')
+    assert C.read_mcp_server(out) == {"command": "/bin/llm-router", "args": []}
+
+
+def test_upsert_replaces_existing_table_in_place_only():
+    text = USER_TOML + '\n[mcp_servers.llm_router]\ncommand = "old"\n\n[mcp_servers.other]\ncommand = "keep"\n'
+    out = C.upsert_toml_table(text, C.MCP_TABLE, C.mcp_table_body("/new", ["--x"]))
+    assert 'command = "old"' not in out
+    assert '[mcp_servers.other]\ncommand = "keep"' in out
+    assert out.startswith(USER_TOML)
+    assert C.read_mcp_server(out) == {"command": "/new", "args": ["--x"]}
+
+
+def test_upsert_into_empty_file():
+    assert C.upsert_toml_table("", "a.b", "k = 1") == "[a.b]\nk = 1\n"
+
+
+def test_remove_table_leaves_neighbours():
+    text = '[a]\nx = 1\n\n[mcp_servers.llm_router]\ncommand = "c"\n\n[b]\ny = 2\n'
+    out = C.remove_toml_table(text, C.MCP_TABLE)
+    assert "[a]\nx = 1" in out and "[b]\ny = 2" in out and "llm_router" not in out
+
+
+def test_quoted_state_table_roundtrips_through_tomllib():
+    key = "/Users/me/.codex/hooks.json:user_prompt_submit:0:0"
+    out = C.upsert_toml_table("[hooks.state]\n", C.hook_state_table(key), 'trusted_hash = "sha256:ab"')
+    assert C.read_trust_records(out) == {key: "sha256:ab"}
+    out2 = C.upsert_toml_table(out, C.hook_state_table(key), 'trusted_hash = "sha256:cd"')
+    assert C.read_trust_records(out2) == {key: "sha256:cd"}
+    assert out2.count("hooks.state.") == 1
+
+
+def test_read_helpers_tolerate_broken_toml():
+    assert C.read_mcp_server("[broken") is None
+    assert C.read_trust_records("[broken") == {}
+
+
+def test_toml_string_escapes():
+    assert C.toml_string('a"b\\c') == '"a\\"b\\\\c"'
+
+
+# ── AGENTS.md ──────────────────────────────────────────────────────────────
+
+def test_marked_block_insert_replace_remove_preserve_user_text():
+    user = "# My agents file\n\nDo things.\n"
+    v1 = C.upsert_marked_block(user, "rules v1")
+    assert v1.startswith(user)
+    assert v1.endswith(f"{C.AGENTS_BLOCK_START}\nrules v1\n{C.AGENTS_BLOCK_END}\n")
+    v2 = C.upsert_marked_block(v1 + "\n## Later section\n", "rules v2")
+    assert "rules v1" not in v2 and "rules v2" in v2
+    assert v2.startswith(user) and v2.rstrip().endswith("## Later section")
+    assert C.remove_marked_block(v2).strip() == (user + "\n## Later section").strip()
+    assert C.upsert_marked_block("", "x") == f"{C.AGENTS_BLOCK_START}\nx\n{C.AGENTS_BLOCK_END}\n"

--- a/tests/test_codex_install.py
+++ b/tests/test_codex_install.py
@@ -1,0 +1,272 @@
+"""The Codex writer: config.toml MCP table, trusted hooks, AGENTS.md, legacy cleanup.
+
+Codex 0.153 reads `~/.codex/config.toml` for MCP servers and silently skips any
+hooks.json hook without a matching `[hooks.state."…"] trusted_hash` record. The
+previous installers wrote config.yaml / config.json / rules/*.md / instructions.md,
+none of which Codex reads, so Codex -> llm-router never worked for anyone.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from llm_router import codex_host, install_manifest
+from llm_router.commands import install
+
+
+@pytest.fixture
+def home(monkeypatch, tmp_path):
+    monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "llm_router.install_hooks._build_mcp_entry",
+        lambda: ({"command": "/opt/llm/bin/llm-router", "args": []}, []),
+    )
+    monkeypatch.setattr("llm_router.install_hooks._python_exe", lambda: "/opt/py/bin/python3")
+    return tmp_path
+
+
+def _toml(home):
+    return (home / ".codex" / "config.toml").read_text()
+
+
+def _hooks(home):
+    return json.loads((home / ".codex" / "hooks.json").read_text())
+
+
+# ── MCP ─────────────────────────────────────────────────────────────────────
+
+def test_mcp_server_lands_in_config_toml_with_absolute_command(home):
+    install._install_codex_files()
+    entry = codex_host.read_mcp_server(_toml(home))
+    assert entry["command"] == "/opt/llm/bin/llm-router" and entry["args"] == []
+    assert not (home / ".codex" / "config.yaml").exists()
+    assert not (home / ".codex" / "config.json").exists()
+
+
+def test_routing_doors_are_auto_approved_for_codex_exec(home):
+    """`codex exec` runs with approval policy "never"; an unapproved MCP tool fails
+    with 'MCP tool call requires approval' instead of routing (observed live)."""
+    import tomllib
+    install._install_codex_files()
+    tools = tomllib.loads(_toml(home))["mcp_servers"]["llm_router"]["tools"]
+    assert tools["llm"] == {"approval_mode": "approve"}
+    assert tools["llm_act"] == {"approval_mode": "approve"}
+    assert "llm_router_admin" not in tools, "admin tools keep prompting"
+
+
+def test_hand_edited_config_toml_survives_byte_for_byte(home):
+    user = (
+        '# mine\nmodel = "gpt-5.5"\nmodel_reasoning_effort = "medium"\n\n'
+        '[model_providers.gemini]\nname = "Gemini"\nbase_url = "https://x/v1"\n\n'
+        '[projects."/Users/me/proj"]\ntrust_level = "trusted"\n\n'
+        '[mcp_servers.chuzom]\ncommand = "/x/chuzom"\nargs = []\n'
+    )
+    (home / ".codex").mkdir()
+    (home / ".codex" / "config.toml").write_text(user)
+    install._install_codex_files()
+    text = _toml(home)
+    assert text.startswith(user)
+    assert codex_host.read_mcp_server(text)["command"] == "/opt/llm/bin/llm-router"
+    # the other MCP server is still there and still parses
+    import tomllib
+    assert tomllib.loads(text)["mcp_servers"]["chuzom"]["command"] == "/x/chuzom"
+
+
+def test_missing_router_binary_warns_and_installs_nothing_unrunnable(home, monkeypatch):
+    monkeypatch.setattr("llm_router.install_hooks._build_mcp_entry", lambda: (None, ["WARN no binary"]))
+    actions = install._install_codex_files()
+    assert any("WARN no binary" in a for a in actions)
+    assert codex_host.read_mcp_server(_toml(home)) is None
+
+
+# ── Hooks + trust ───────────────────────────────────────────────────────────
+
+def test_hooks_are_registered_and_trusted(home):
+    install._install_codex_files()
+    doc = _hooks(home)
+    route_cmd = f"/opt/py/bin/python3 {home}/.llm-router/hooks/codex-auto-route.py"
+    post_cmd = f"{home}/.llm-router/hooks/codex-post-tool.py"
+    assert doc["hooks"]["UserPromptSubmit"] == [{"hooks": [{"type": "command", "command": route_cmd}]}]
+    assert doc["hooks"]["PostToolUse"] == [{"matcher": "Bash", "hooks": [{"type": "command", "command": post_cmd}]}]
+    assert (home / ".llm-router" / "hooks" / "codex-auto-route.py").exists()
+    assert (home / ".llm-router" / "hooks" / "llm_router_tool_surface.py").exists()
+
+    hooks_json = home / ".codex" / "hooks.json"
+    records = codex_host.read_trust_records(_toml(home))
+    expected = codex_host.trust_records(hooks_json, doc)
+    assert records == expected and len(records) == 2, "every hook we wrote must carry its trust record"
+    assert records[f"{hooks_json}:user_prompt_submit:0:0"] == codex_host.hook_trust_hash(
+        "UserPromptSubmit", {"type": "command", "command": route_cmd})
+
+
+def test_existing_user_hooks_keep_their_index_and_are_not_trusted_by_us(home):
+    (home / ".codex").mkdir()
+    (home / ".codex" / "hooks.json").write_text(json.dumps({"hooks": {
+        "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "/theirs.sh"}]}],
+        "PostToolUse": [{"matcher": "Write", "hooks": [{"type": "command", "command": "/theirs2.sh"}]}],
+    }}))
+    install._install_codex_files()
+    doc = _hooks(home)
+    assert doc["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"] == "/theirs.sh"
+    assert "codex-auto-route.py" in doc["hooks"]["UserPromptSubmit"][1]["hooks"][0]["command"]
+    records = codex_host.read_trust_records(_toml(home))
+    hooks_json = home / ".codex" / "hooks.json"
+    assert f"{hooks_json}:user_prompt_submit:1:0" in records
+    assert f"{hooks_json}:post_tool_use:1:0" in records
+    assert f"{hooks_json}:user_prompt_submit:0:0" not in records, "we must not vouch for someone else's hook"
+
+
+def test_rerun_is_idempotent(home):
+    install._install_codex_files()
+    first_toml, first_hooks = _toml(home), _hooks(home)
+    actions = install._install_codex_files()
+    assert _toml(home) == first_toml
+    assert _hooks(home) == first_hooks
+    assert any("already" in a.lower() for a in actions)
+
+
+def test_moved_python_updates_the_trust_record(home, monkeypatch):
+    install._install_codex_files()
+    old = codex_host.read_trust_records(_toml(home))
+    monkeypatch.setattr("llm_router.install_hooks._python_exe", lambda: "/new/python3")
+    install._install_codex_files()
+    doc = _hooks(home)
+    cmds = [h["command"] for g in doc["hooks"]["UserPromptSubmit"] for h in g["hooks"]]
+    assert len(cmds) == 2, "a new interpreter path is a new hook entry, the old one is left for the user"
+    new = codex_host.read_trust_records(_toml(home))
+    assert set(old) < set(new)
+
+
+def test_corrupt_hooks_json_is_left_alone(home):
+    (home / ".codex").mkdir()
+    (home / ".codex" / "hooks.json").write_text("{not json")
+    actions = install._install_codex_files()
+    assert (home / ".codex" / "hooks.json").read_text() == "{not json"
+    assert any("not valid JSON" in a for a in actions)
+    assert codex_host.read_trust_records(_toml(home)) == {}
+
+
+# ── AGENTS.md ───────────────────────────────────────────────────────────────
+
+def test_agents_md_block_is_upserted_and_user_text_preserved(home):
+    (home / ".codex").mkdir()
+    (home / ".codex" / "AGENTS.md").write_text("# House rules\n\nBe brief.\n")
+    install._install_codex_files()
+    text = (home / ".codex" / "AGENTS.md").read_text()
+    assert text.startswith("# House rules\n\nBe brief.\n")
+    assert codex_host.AGENTS_BLOCK_START in text and codex_host.AGENTS_BLOCK_END in text
+    assert "llm_router" in text.lower() or "llm-router" in text.lower()
+    assert not (home / ".codex" / "instructions.md").exists()
+    assert not (home / ".codex" / "rules" / "llm_router.md").exists()
+    install._install_codex_files()
+    assert (home / ".codex" / "AGENTS.md").read_text().count(codex_host.AGENTS_BLOCK_START) == 1
+
+
+# ── Legacy cleanup ──────────────────────────────────────────────────────────
+
+def test_legacy_files_codex_never_read_are_cleaned(home):
+    codex = home / ".codex"
+    codex.mkdir()
+    (codex / "config.yaml").write_text("other: 1\n" + install._CODEX_LEGACY_YAML_BLOCK)
+    (codex / "config.json").write_text(json.dumps({"mcpServers": {
+        "chuzom": {"command": "chuzom", "args": []},
+        "llm-router": {"command": "uvx", "args": ["claude-code-llm-router"]},
+        "llm_router": {"command": "llm-router", "args": []},
+    }}))
+    (codex / "rules").mkdir()
+    (codex / "rules" / "llm_router.md").write_text("<!-- llm_router-rules-version: 2 -->\n# rules\n")
+    (codex / "rules" / "mine.md").write_text("keep\n")
+    (codex / "instructions.md").write_text("<!-- llm_router-rules-version: 2 -->\n# rules\n")
+    install_manifest.record("created_file", codex / "instructions.md")
+
+    actions = install._install_codex_files()
+    assert (codex / "config.yaml").read_text() == "other: 1\n"
+    assert json.loads((codex / "config.json").read_text()) == {"mcpServers": {"chuzom": {"command": "chuzom", "args": []}}}
+    assert not (codex / "rules" / "llm_router.md").exists()
+    assert (codex / "rules" / "mine.md").exists()
+    assert not (codex / "instructions.md").exists()
+    assert sum(a.startswith("✓ Removed legacy") for a in actions) == 4
+
+
+def test_legacy_cleanup_leaves_files_that_are_not_ours(home):
+    codex = home / ".codex"
+    codex.mkdir()
+    (codex / "config.yaml").write_text("mcp:\n  servers:\n    llm_router:\n      command: /custom\n")
+    (codex / "instructions.md").write_text("# my own instructions mentioning llm_router\n")
+    (codex / "rules").mkdir()
+    (codex / "rules" / "llm_router.md").write_text("# hand-written\n")
+    install._install_codex_files()
+    assert "/custom" in (codex / "config.yaml").read_text()
+    assert (codex / "instructions.md").read_text() == "# my own instructions mentioning llm_router\n"
+    assert (codex / "rules" / "llm_router.md").read_text() == "# hand-written\n"
+
+
+# ── Uninstall ───────────────────────────────────────────────────────────────
+
+def test_uninstall_removes_only_what_we_wrote(home):
+    codex = home / ".codex"
+    codex.mkdir()
+    (codex / "config.toml").write_text('model = "gpt-5.5"\n\n[mcp_servers.chuzom]\ncommand = "/x"\n')
+    (codex / "hooks.json").write_text(json.dumps({"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "/theirs"}]}]}}))
+    (codex / "AGENTS.md").write_text("# mine\n")
+    install._install_codex_files()
+    install_manifest.apply_uninstall()
+
+    text = _toml(home)
+    assert 'model = "gpt-5.5"' in text and "[mcp_servers.chuzom]" in text
+    assert codex_host.read_mcp_server(text) is None
+    assert codex_host.read_trust_records(text) == {}
+    doc = _hooks(home)
+    assert doc["hooks"]["Stop"] == [{"hooks": [{"type": "command", "command": "/theirs"}]}]
+    assert doc["hooks"].get("UserPromptSubmit", []) == []
+    assert (codex / "AGENTS.md").read_text() == "# mine\n"
+    assert not (home / ".llm-router" / "hooks" / "codex-auto-route.py").exists()
+
+
+# ── Autodetect from the plain install ──────────────────────────────────────
+
+def test_plain_install_wires_codex_when_detected(home, monkeypatch, capsys):
+    from llm_router import host_detect, seats as S
+    monkeypatch.setattr("llm_router.install_hooks.install", lambda force=False: ["claude ok"])
+    monkeypatch.setattr("llm_router.install_hooks.install_claw_code", lambda: [])
+    monkeypatch.setattr("llm_router.install_hooks.claw_code_settings_path", lambda: None)
+    monkeypatch.setattr("llm_router.install_hooks.check_api_keys", lambda: [])
+    monkeypatch.setattr(host_detect, "detect_hosts", lambda **kw: {
+        "claude-code": host_detect.HostInfo("claude-code", "/bin/claude", None),
+        "codex": host_detect.HostInfo("codex", "/bin/codex", None),
+        "gemini-cli": host_detect.HostInfo("gemini-cli", None, None),
+    })
+    fake = S.Seats(claude=S.Seat(kind="claude.ai", plan="max"), codex=S.Seat(kind="chatgpt", plan="pro"),
+                   detected_at="2026-09-04T00:00:00+00:00")
+    monkeypatch.setattr(S, "refresh_seats", lambda **kw: fake)
+
+    install._run_install([])
+    out = capsys.readouterr().out
+    assert "Codex CLI detected" in out
+    assert codex_host.read_mcp_server(_toml(home)) is not None
+    assert "Seats" in out and "claude.ai(max)" in out and "free bucket: claude, codex" in out
+    assert "Every Claude Code and Codex CLI session" in out
+
+
+def test_plain_install_skips_codex_with_no_hosts_or_when_absent(home, monkeypatch, capsys):
+    from llm_router import host_detect
+    monkeypatch.setattr("llm_router.install_hooks.install", lambda force=False: [])
+    monkeypatch.setattr("llm_router.install_hooks.install_claw_code", lambda: [])
+    monkeypatch.setattr("llm_router.install_hooks.claw_code_settings_path", lambda: None)
+    monkeypatch.setattr("llm_router.install_hooks.check_api_keys", lambda: [])
+    monkeypatch.setattr("llm_router.seats.refresh_seats", lambda **kw: (_ for _ in ()).throw(OSError("no")))
+    present = {"codex": host_detect.HostInfo("codex", "/bin/codex", None),
+               "claude-code": host_detect.HostInfo("claude-code", None, None),
+               "gemini-cli": host_detect.HostInfo("gemini-cli", None, None)}
+    monkeypatch.setattr(host_detect, "detect_hosts", lambda **kw: present)
+    install._run_install(["--no-hosts"])
+    assert not (home / ".codex" / "config.toml").exists()
+
+    absent = {k: host_detect.HostInfo(k, None, None) for k in present}
+    monkeypatch.setattr(host_detect, "detect_hosts", lambda **kw: absent)
+    install._run_install([])
+    assert not (home / ".codex" / "config.toml").exists()
+    assert "Codex CLI detected" not in capsys.readouterr().out

--- a/tests/test_codex_install.py
+++ b/tests/test_codex_install.py
@@ -62,7 +62,7 @@ def test_hand_edited_config_toml_survives_byte_for_byte(home):
         '# mine\nmodel = "gpt-5.5"\nmodel_reasoning_effort = "medium"\n\n'
         '[model_providers.gemini]\nname = "Gemini"\nbase_url = "https://x/v1"\n\n'
         '[projects."/Users/me/proj"]\ntrust_level = "trusted"\n\n'
-        '[mcp_servers.chuzom]\ncommand = "/x/chuzom"\nargs = []\n'
+        '[mcp_servers.other_mcp]\ncommand = "/x/other_mcp"\nargs = []\n'
     )
     (home / ".codex").mkdir()
     (home / ".codex" / "config.toml").write_text(user)
@@ -72,7 +72,7 @@ def test_hand_edited_config_toml_survives_byte_for_byte(home):
     assert codex_host.read_mcp_server(text)["command"] == "/opt/llm/bin/llm-router"
     # the other MCP server is still there and still parses
     import tomllib
-    assert tomllib.loads(text)["mcp_servers"]["chuzom"]["command"] == "/x/chuzom"
+    assert tomllib.loads(text)["mcp_servers"]["other_mcp"]["command"] == "/x/other_mcp"
 
 
 def test_missing_router_binary_warns_and_installs_nothing_unrunnable(home, monkeypatch):
@@ -172,7 +172,7 @@ def test_legacy_files_codex_never_read_are_cleaned(home):
     codex.mkdir()
     (codex / "config.yaml").write_text("other: 1\n" + install._CODEX_LEGACY_YAML_BLOCK)
     (codex / "config.json").write_text(json.dumps({"mcpServers": {
-        "chuzom": {"command": "chuzom", "args": []},
+        "other_mcp": {"command": "other_mcp", "args": []},
         "llm-router": {"command": "uvx", "args": ["claude-code-llm-router"]},
         "llm_router": {"command": "llm-router", "args": []},
     }}))
@@ -184,7 +184,7 @@ def test_legacy_files_codex_never_read_are_cleaned(home):
 
     actions = install._install_codex_files()
     assert (codex / "config.yaml").read_text() == "other: 1\n"
-    assert json.loads((codex / "config.json").read_text()) == {"mcpServers": {"chuzom": {"command": "chuzom", "args": []}}}
+    assert json.loads((codex / "config.json").read_text()) == {"mcpServers": {"other_mcp": {"command": "other_mcp", "args": []}}}
     assert not (codex / "rules" / "llm_router.md").exists()
     assert (codex / "rules" / "mine.md").exists()
     assert not (codex / "instructions.md").exists()
@@ -209,14 +209,14 @@ def test_legacy_cleanup_leaves_files_that_are_not_ours(home):
 def test_uninstall_removes_only_what_we_wrote(home):
     codex = home / ".codex"
     codex.mkdir()
-    (codex / "config.toml").write_text('model = "gpt-5.5"\n\n[mcp_servers.chuzom]\ncommand = "/x"\n')
+    (codex / "config.toml").write_text('model = "gpt-5.5"\n\n[mcp_servers.other_mcp]\ncommand = "/x"\n')
     (codex / "hooks.json").write_text(json.dumps({"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "/theirs"}]}]}}))
     (codex / "AGENTS.md").write_text("# mine\n")
     install._install_codex_files()
     install_manifest.apply_uninstall()
 
     text = _toml(home)
-    assert 'model = "gpt-5.5"' in text and "[mcp_servers.chuzom]" in text
+    assert 'model = "gpt-5.5"' in text and "[mcp_servers.other_mcp]" in text
     assert codex_host.read_mcp_server(text) is None
     assert codex_host.read_trust_records(text) == {}
     doc = _hooks(home)

--- a/tests/test_first_forty_w3_hook_io.py
+++ b/tests/test_first_forty_w3_hook_io.py
@@ -47,13 +47,27 @@ def test_claude_code_tool_payload_normalizes():
     assert req.tool_input == {"command": "ls"}
 
 
-@pytest.mark.parametrize("host", ["codex", "cursor"])
+@pytest.mark.parametrize("host", ["cursor"])
 def test_unported_host_refuses_to_normalize_a_prompt(host):
     """Reading a documented-but-unverified key is how a port fails silently."""
     with pytest.raises(UnverifiedHost) as exc:
         normalize(host, Event.PROMPT_SUBMIT, {"prompt": "hi", "session_id": "s"})
     assert "prompt_key" in exc.value.missing
     assert "Do not fill them in" in str(exc.value)
+
+
+def test_codex_prompt_is_ported_but_its_tool_events_are_not():
+    """Codex's UserPromptSubmit keys were captured from a real run (2026-09-04,
+    tests/fixtures/codex_user_prompt_submit.json); its PreToolUse keys were not."""
+    import json
+    import pathlib
+    payload = json.loads((pathlib.Path(__file__).parent / "fixtures" / "codex_user_prompt_submit.json").read_text())
+    req = normalize("codex", Event.PROMPT_SUBMIT, payload)
+    assert req.prompt == "Reply with the single word: pong"
+    assert req.session_id.startswith("01a06e3d")
+    with pytest.raises(UnverifiedHost) as exc:
+        normalize("codex", Event.PRE_TOOL, {"tool_name": "Bash", "tool_input": {}})
+    assert "tool_name_key" in exc.value.missing
 
 
 def test_unknown_host_is_a_hard_error():


### PR DESCRIPTION
PR 2 of 4 from `guide/PLAN_DUAL_HOST_INSTALL.md`. Stacked on #128.

**Why.** Codex → llm-router has never worked for anyone. The installer wrote the MCP server to `~/.codex/config.yaml` (and an older path to `config.json` + `rules/llm_router.md`); Codex reads only `config.toml`. `doctor --host codex` validated `config.yaml`, so a broken install reported healthy.

**What Codex actually needs (verified against 0.153.2 on 2026-09-04).**
- MCP servers in `config.toml` under `[mcp_servers.llm_router]`.
- A `[hooks.state."<hooks.json>:<event>:<group>:<handler>"] trusted_hash` record per hook, or the hook is **silently skipped**. The hash is SHA-256 over a canonical-JSON identity of the hook (`llm_router.codex_host`), derived from `codex-rs/hooks/src/engine/discovery.rs`. With the record the hook fired; without it, nothing.
- `[mcp_servers.llm_router.tools.<tool>] approval_mode = "approve"`, or `codex exec` (approval policy `never`) fails every tool call with "requires approval".

**What changed.**
- `codex_host.py`: trust hash, state keys, surgical TOML upsert (the `codex mcp add` CLI rewrites the whole file), AGENTS.md marked block. Golden test pins the hash Codex accepted.
- One Codex writer in `commands/install.py`; the duplicate in `cli.py` is gone. Writes `config.toml`, `hooks.json` (`UserPromptSubmit` → auto-route, `PostToolUse` → telemetry), `AGENTS.md`; removes legacy `config.yaml` / `config.json` / `rules/llm_router.md` / `instructions.md` entries when recognisably ours. Gateway mode is opt-in.
- `llm-router install` auto-detects Codex and wires it in the same run (`--no-hosts` opts out), then prints the seat table.
- `doctor`: Codex CLI section. Fails on missing registration, unrunnable command, `codex mcp list` disagreeing, or an untrusted/stale hook.
- `hosts/events.py`: verified Codex prompt keys, with the real payload as a fixture. Tool-event keys stay honestly unverified.
- Manifest: `codex_hooks` and `codex_agents_block` kinds so uninstall removes only what we wrote.

**Verified live** from a `codex exec` session on a real machine: the injected ⚡ ROUTE directive reached the model, and a call to the `llm` tool was routed to Ollama at $0.

**Tests.** 39 new. Full suite green (two timing-sensitive tests errored under concurrent load and pass in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LktEjGmgYMKstVfPC7NGtt