### PR TITLE
feat(routing): derive the subscription seat and free bucket from seats.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Routing defaults come from the seat table.** With
+  `LLM_ROUTER_SUBSCRIPTION_PROVIDER` unset, the strongest logged-in seat is
+  the subscription provider (Claude over ChatGPT over Google) and the other
+  seats join the free bucket, so a Claude Max + ChatGPT machine sends cheap
+  work to Codex and hard work to Claude from either host, with nothing
+  configured. The env var still wins; `LLM_ROUTER_SEATS_AUTO=off` restores
+  env-only behaviour.
 - **`llm-router install` auto-detects Codex.** With no `--host`, a machine
   that has Codex gets it wired in the same run, and the seat table prints at
   the end. `--no-hosts` opts out; `--host codex` is unchanged. Gateway mode is

--- a/guide/PLAN_DUAL_HOST_INSTALL.md
+++ b/guide/PLAN_DUAL_HOST_INSTALL.md
@@ -1,6 +1,6 @@
 # Plan: one install that wires Claude Code AND Codex, and knows which seats you pay for
 
-Status: 2026-09-04 — PR 1 (#128, seats) open; PR 2 (Codex writer, autodetect, doctor, push hook) on `feat/codex-dual-host`. PR 3, 4 not started.
+Status: 2026-09-04 — PR 1 (#128, seats) open; PR 2 (Codex writer, autodetect, doctor, push hook) on `feat/codex-dual-host`. PR 3 (seat-derived defaults) on `feat/seat-derived-routing`. PR 4 not started.
 
 ## Goal
 

--- a/src/llm_router/env_registry.py
+++ b/src/llm_router/env_registry.py
@@ -219,6 +219,7 @@ ENV_REGISTRY: dict[str, tuple[str, str, int]] = {
     "LLM_ROUTER_PROJECT_ID": ("provider_credential", "session_store.py", 1),
     "LLM_ROUTER_RESPONSE_ROUTER_TOKEN_THRESHOLD": ("provider_credential", "response_router.py", 1),
     "LLM_ROUTER_SCIM_TOKEN": ("provider_credential", "admin_api.py", 2),
+    "LLM_ROUTER_SEATS_AUTO": ("llm_router", "subscription_local_routing.py", 1),
     "LLM_ROUTER_SUBSCRIPTION_PROVIDER": ("llm_router", "subscription_local_routing.py", 2),
     "LLM_ROUTER_TOKEN": ("provider_credential", "identity.py", 1),
     "DEEPSEEK_API_KEY": ("provider_credential", "commands/doctor.py", 1),

--- a/src/llm_router/seats.py
+++ b/src/llm_router/seats.py
@@ -103,8 +103,33 @@ class Seats:
         return frozenset(out)
 
     def subscription_provider(self) -> str | None:
-        """Default for ``LLM_ROUTER_SUBSCRIPTION_PROVIDER`` when unset."""
-        return "claude" if self.claude.present else None
+        """Default for ``LLM_ROUTER_SUBSCRIPTION_PROVIDER`` when unset, in
+        that variable's vocabulary (``anthropic`` / ``openai`` / ``gemini``).
+
+        The strongest seat heads complex chains: a Claude seat over a
+        ChatGPT seat over a Google one. The seats that are not the
+        subscription join the free bucket (:meth:`seat_free_providers`), so
+        a machine with Claude Max and ChatGPT routes cheap work to Codex and
+        hard work to Claude, from either host.
+        """
+        if self.claude.present:
+            return "anthropic"
+        if self.codex.present:
+            return "openai"
+        if self.gemini.present:
+            return "gemini"
+        return None
+
+    def seat_free_providers(self) -> frozenset[str]:
+        """Chain provider names that are free because a seat covers them and
+        it is not the subscription seat. Ollama is already in LOCAL_PROVIDERS."""
+        sub = self.subscription_provider()
+        out = set()
+        if self.codex.present and sub != "openai":
+            out.add("codex")
+        if self.gemini.present and sub != "gemini":
+            out.add("gemini_cli")
+        return frozenset(out)
 
     def summary_line(self) -> str:
         return (

--- a/src/llm_router/subscription_local_routing.py
+++ b/src/llm_router/subscription_local_routing.py
@@ -24,9 +24,11 @@ cost up to the quota."
 Configuration:
 
 * ``LLM_ROUTER_SUBSCRIPTION_PROVIDER`` — single provider name
-  (e.g. ``anthropic`` / ``openai`` / ``gemini``). Empty / unset →
-  the profile no-ops (chain passes through unchanged), preserving
-  backward compatibility.
+  (e.g. ``anthropic`` / ``openai`` / ``gemini``). Unset → the seat
+  table written by install / doctor / session-start
+  (``~/.llm-router/seats.json``, see ``llm_router.seats``) supplies
+  the strongest logged-in seat. No env and no seat → the profile
+  no-ops. ``LLM_ROUTER_SEATS_AUTO=off`` disables the seat default.
 * ``LLM_ROUTER_INTERNAL_PROVIDERS`` — comma-separated provider names
   the org hosts internally (e.g. ``internal_llm,company_mistral``).
   These join ``LOCAL_PROVIDERS`` to form the "free bucket."
@@ -83,11 +85,38 @@ _PROVIDER_TO_PRESSURE_KEY: dict[str, str] = {
 }
 
 
+def _seats_auto_enabled() -> bool:
+    """Seat-derived defaults are on unless ``LLM_ROUTER_SEATS_AUTO`` is off-ish."""
+    raw = (os.environ.get("LLM_ROUTER_SEATS_AUTO") or "").strip().lower()
+    return raw not in _REORDER_OFF_VALUES
+
+
+def _cached_seats():
+    """The seat table install / doctor / session-start wrote, or ``None``.
+    A missing or unreadable cache means "no seat known" -- never an error."""
+    if not _seats_auto_enabled():
+        return None
+    try:
+        from llm_router.seats import load_seats
+        return load_seats()
+    except Exception:  # noqa: BLE001 -- a cache problem must not break routing
+        return None
+
+
 def get_subscription_provider() -> str | None:
-    """Return the org's subscription provider name, or ``None`` when
-    unset (the profile then no-ops)."""
+    """Return the subscription provider name, or ``None`` when there is none.
+
+    ``LLM_ROUTER_SUBSCRIPTION_PROVIDER`` wins when set. Otherwise the seat
+    table (``~/.llm-router/seats.json``) supplies the default: the strongest
+    logged-in seat, so a user who is logged in to Claude Code gets the
+    cost-inverted reorder without setting anything. ``LLM_ROUTER_SEATS_AUTO=off``
+    restores the env-only behaviour.
+    """
     raw = (os.environ.get(_SUBSCRIPTION_PROVIDER_ENV) or "").strip().lower()
-    return raw or None
+    if raw:
+        return raw
+    seats = _cached_seats()
+    return seats.subscription_provider() if seats is not None else None
 
 
 def get_internal_providers() -> frozenset[str]:
@@ -105,10 +134,15 @@ def get_internal_providers() -> frozenset[str]:
 
 
 def get_free_bucket() -> frozenset[str]:
-    """Union of LOCAL_PROVIDERS + LLM_ROUTER_INTERNAL_PROVIDERS. Both
-    tiers are "zero incremental cost to the org" so the router
-    treats them identically."""
-    return LOCAL_PROVIDERS | get_internal_providers()
+    """Union of LOCAL_PROVIDERS + LLM_ROUTER_INTERNAL_PROVIDERS + the seats that
+    are logged in but are not the subscription seat (a ChatGPT seat makes
+    ``codex`` free; a Google seat makes ``gemini_cli`` free). All are "zero
+    incremental cost" so the router treats them identically."""
+    bucket = LOCAL_PROVIDERS | get_internal_providers()
+    seats = _cached_seats()
+    if seats is not None:
+        bucket = bucket | seats.seat_free_providers()
+    return bucket
 
 
 def _provider_of(model_id: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -710,6 +710,11 @@ def _hermetic_host_state(monkeypatch):
     monkeypatch.setattr(repo_config_module, "load_user_config", lambda *a, **k: RepoConfig())
     monkeypatch.setattr(router_module, "is_codex_available", lambda: False)
     monkeypatch.setattr(router_module, "is_gemini_cli_available", lambda: False)
+    # 3. The seat table (~/.llm-router/seats.json) supplies the subscription
+    #    provider and free-bucket defaults when the env is unset. A developer
+    #    logged in to Claude Code would otherwise get a reordered chain in
+    #    every test. Tests of the seat default re-enable it explicitly.
+    monkeypatch.setenv("LLM_ROUTER_SEATS_AUTO", "off")
     # The LLM-first ensemble makes live Ollama classifier calls, which in unit
     # tests punch through host-state isolation — real model latency,
     # non-determinism, and background warmup threads that leak global state

--- a/tests/test_doctor_seats.py
+++ b/tests/test_doctor_seats.py
@@ -37,7 +37,7 @@ def test_doctor_lists_every_seat_and_the_free_bucket(monkeypatch, tmp_path):
     assert "Gemini CLI api key only" in text
     assert "local(2 models)" in text
     assert "free bucket: claude, codex, ollama" in text
-    assert "defaults to 'claude'" in text
+    assert "defaults to 'anthropic'" in text
     # persisted for the session hook
     assert (tmp_path / ".llm-router" / "seats.json").exists()
 
@@ -56,7 +56,7 @@ def test_doctor_flags_env_override_that_disagrees_with_the_seat(monkeypatch, tmp
     seats = S.Seats(claude=S.Seat(kind="claude.ai", plan="pro"), detected_at="2026-09-04T00:00:00+00:00")
     monkeypatch.setattr(S, "refresh_seats", _fake_refresh(seats))
     text = "\n".join(doc._seats_report())
-    assert "LLM_ROUTER_SUBSCRIPTION_PROVIDER=gemini but the detected seat is 'claude'" in text
+    assert "LLM_ROUTER_SUBSCRIPTION_PROVIDER=gemini but the detected seat is 'anthropic'" in text
 
 
 def test_doctor_never_crashes_on_a_probe_error(monkeypatch, tmp_path):

--- a/tests/test_seats_detection.py
+++ b/tests/test_seats_detection.py
@@ -203,13 +203,31 @@ def test_free_bucket_is_local_plus_every_seat(tmp_path):
         models=["m"],
     )
     assert seats.free_bucket() == frozenset({"ollama", "codex", "claude"})
-    assert seats.subscription_provider() == "claude"
+    assert seats.subscription_provider() == "anthropic"
+    assert seats.seat_free_providers() == frozenset({"codex"})
 
 
 def test_no_seats_means_empty_bucket_and_no_subscription_default(tmp_path):
     seats = _detect(tmp_path, env={"OPENAI_API_KEY": "k"})
     assert seats.free_bucket() == frozenset()
     assert seats.subscription_provider() is None
+
+
+def test_subscription_seat_priority_and_free_providers(tmp_path):
+    """Strongest seat is the subscription; the others become free providers."""
+    _codex_auth(tmp_path)
+    both = _detect(tmp_path, runner=_runner({"claude auth": CLAUDE_MAX, "codex login": CODEX_CHATGPT}))
+    assert both.subscription_provider() == "anthropic"
+    assert both.seat_free_providers() == frozenset({"codex"})
+    codex_only = _detect(tmp_path, runner=_runner({"codex login": CODEX_CHATGPT}))
+    assert codex_only.subscription_provider() == "openai"
+    assert codex_only.seat_free_providers() == frozenset()
+    (tmp_path / ".gemini").mkdir(exist_ok=True)
+    (tmp_path / ".gemini" / "oauth_creds.json").write_text("{}")
+    gem = _detect(tmp_path, runner=_runner({"codex login": CODEX_CHATGPT}),
+                  which=lambda b: "/usr/bin/gemini" if b == "gemini" else None)
+    assert gem.subscription_provider() == "openai"
+    assert gem.seat_free_providers() == frozenset({"gemini_cli"})
 
 
 def test_summary_line_names_every_seat(tmp_path):

--- a/tests/test_subscription_local_routing.py
+++ b/tests/test_subscription_local_routing.py
@@ -47,6 +47,77 @@ def _clean_env(monkeypatch) -> None:
         "LLM_ROUTER_SUBSCRIPTION_REORDER_ALL_PROFILES",
     ):
         monkeypatch.delenv(env, raising=False)
+    # conftest turns the seat default off for every test; the seat tests
+    # below re-enable it against a temp home.
+    monkeypatch.setenv("LLM_ROUTER_SEATS_AUTO", "off")
+
+
+# ── 0. Seat-derived defaults ────────────────────────────────────────────────
+
+
+@pytest.fixture
+def seat_home(monkeypatch, tmp_path):
+    import pathlib
+    monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LLM_ROUTER_SEATS_AUTO", "on")
+    return tmp_path
+
+
+def _write_seats(home, **kw):
+    from llm_router import seats as S
+    S.save_seats(S.Seats(detected_at="2026-09-04T00:00:00+00:00", **kw), home)
+
+
+def test_seat_table_supplies_the_subscription_provider_when_env_unset(seat_home) -> None:
+    from llm_router import seats as S
+    _write_seats(seat_home, claude=S.Seat(kind="claude.ai", plan="max"), codex=S.Seat(kind="chatgpt", plan="plus"))
+    assert get_subscription_provider() == "anthropic"
+    assert "codex" in get_free_bucket()
+    assert is_subscription_local_active(RoutingProfile.BALANCED)
+
+
+def test_env_wins_over_the_seat_table(seat_home, monkeypatch) -> None:
+    from llm_router import seats as S
+    _write_seats(seat_home, claude=S.Seat(kind="claude.ai", plan="max"))
+    monkeypatch.setenv("LLM_ROUTER_SUBSCRIPTION_PROVIDER", "openai")
+    assert get_subscription_provider() == "openai"
+
+
+def test_seats_auto_off_restores_env_only_behaviour(seat_home, monkeypatch) -> None:
+    from llm_router import seats as S
+    _write_seats(seat_home, claude=S.Seat(kind="claude.ai", plan="max"), codex=S.Seat(kind="chatgpt"))
+    monkeypatch.setenv("LLM_ROUTER_SEATS_AUTO", "off")
+    assert get_subscription_provider() is None
+    assert "codex" not in get_free_bucket()
+    assert not is_subscription_local_active(RoutingProfile.BALANCED)
+
+
+def test_no_cache_or_no_seat_means_no_default(seat_home) -> None:
+    from llm_router import seats as S
+    assert get_subscription_provider() is None          # no seats.json at all
+    _write_seats(seat_home, codex=S.Seat(kind="api-key"))
+    assert get_subscription_provider() is None          # an API key is not a seat
+    assert "codex" not in get_free_bucket()
+
+
+def test_codex_seat_alone_is_the_subscription_not_free(seat_home) -> None:
+    from llm_router import seats as S
+    _write_seats(seat_home, codex=S.Seat(kind="chatgpt", plan="pro"))
+    assert get_subscription_provider() == "openai"
+    assert "codex" not in get_free_bucket()
+
+
+def test_seat_default_drives_the_reorder_end_to_end(seat_home) -> None:
+    """Claude Max + ChatGPT: cheap work goes free-first (Codex is free), hard
+    work goes to the Claude seat first -- from either host."""
+    from llm_router import seats as S
+    _write_seats(seat_home, claude=S.Seat(kind="claude.ai", plan="max"), codex=S.Seat(kind="chatgpt", plan="plus"))
+    chain = ["anthropic/claude-opus", "openai/gpt-5", "codex/gpt-5.5", "ollama/qwen"]
+    simple = reorder_for_subscription_local(chain, complexity="simple", profile=RoutingProfile.BALANCED)
+    assert simple == ["codex/gpt-5.5", "ollama/qwen", "anthropic/claude-opus", "openai/gpt-5"]
+    complex_ = reorder_for_subscription_local(chain, complexity="complex", profile=RoutingProfile.BALANCED)
+    assert complex_ == ["anthropic/claude-opus", "codex/gpt-5.5", "ollama/qwen", "openai/gpt-5"]
 
 
 # ── 1. Configuration accessors ──────────────────────────────────────────────


### PR DESCRIPTION
PR 3 of 4 from `guide/PLAN_DUAL_HOST_INSTALL.md`. Stacked on #129.

**What.** With `LLM_ROUTER_SUBSCRIPTION_PROVIDER` unset, the seat table (`~/.llm-router/seats.json`, written by install / doctor / session-start) supplies the default: the strongest logged-in seat is the subscription provider (Claude over ChatGPT over Google) and the other seats join the free bucket.

**Effect.** A Claude Max + ChatGPT machine sends simple/moderate work to Codex and Ollama first and complex work to the Claude seat first, from either host, with nothing configured. The existing cost-inverted reorder does the work; this only changes where its two inputs come from. The env var still wins; `LLM_ROUTER_SEATS_AUTO=off` restores env-only behaviour.

**Verified on a real machine**: subscription `anthropic`, free bucket includes `codex`, reorder active under BALANCED with no env set.

**Tests.** 7 new. The hermetic conftest fixture turns the seat default off so a developer logged in to Claude Code does not get a reordered chain in unrelated tests; the seat tests re-enable it against a temp home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LktEjGmgYMKstVfPC7NGtt