### PR TITLE
feat(install): --project writes one rules file both agents read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   work to Codex and hard work to Claude from either host, with nothing
   configured. The env var still wins; `LLM_ROUTER_SEATS_AUTO=off` restores
   env-only behaviour.
+- **`llm-router install --project`** writes a marked llm-router block into the
+  repository's `AGENTS.md` and links `CLAUDE.md` to it (a copy on Windows; an
+  existing `CLAUDE.md` file is kept and gets the same block), so Claude Code and
+  Codex read one set of project rules.
 - **`llm-router install` auto-detects Codex.** With no `--host`, a machine
   that has Codex gets it wired in the same run, and the seat table prints at
   the end. `--no-hosts` opts out; `--host codex` is unchanged. Gateway mode is

--- a/guide/PLAN_DUAL_HOST_INSTALL.md
+++ b/guide/PLAN_DUAL_HOST_INSTALL.md
@@ -1,6 +1,6 @@
 # Plan: one install that wires Claude Code AND Codex, and knows which seats you pay for
 
-Status: 2026-09-04 — PR 1 (#128, seats) open; PR 2 (Codex writer, autodetect, doctor, push hook) on `feat/codex-dual-host`. PR 3 (seat-derived defaults) on `feat/seat-derived-routing`. PR 4 not started.
+Status: 2026-09-04 — PR 1 (#128, seats) open; PR 2 (Codex writer, autodetect, doctor, push hook) on `feat/codex-dual-host`. PR 3 = #130 (seat-derived defaults); PR 4 (`--project`) on `feat/project-agents-md`. All four coded; merge in order.
 
 ## Goal
 

--- a/src/llm_router/commands/install.py
+++ b/src/llm_router/commands/install.py
@@ -60,6 +60,9 @@ Usage:
                                      (claude-code, claude-desktop, cursor, copilot,
                                      windsurf, gemini-cli, codex, …)
   llm-router install --mode <mode>       Install mode (auto | gateway)
+  llm-router install --no-hosts          Claude Code only; skip other detected hosts (Codex)
+  llm-router install --project           Write AGENTS.md + CLAUDE.md (link) into the current
+                                     repository so both agents read one set of rules
   llm-router install --help, -h          Show this help and exit (no changes made)
 """
 
@@ -101,6 +104,12 @@ def _run_install(flags: list[str]) -> None:
             _install_host(host, mode=mode)
             return
         flags = [f for i, f in enumerate(flags) if i not in (idx, idx + 1)]
+
+    if "--project" in flags:
+        import pathlib
+        for a in _install_project_files(pathlib.Path.cwd()):
+            print(f"  {a}")
+        return
 
     check_only = "--check" in flags
     force = "--force" in flags
@@ -732,6 +741,73 @@ def _install_codex_files(mode: str = "mcp") -> list[str]:
     elif mode not in {"mcp", "companion", "mcp-only", "rules", "auto"}:
         actions.append(f"  Unknown Codex mode {mode!r}; installed MCP, hooks and rules only")
 
+    return actions
+
+
+def _install_project_files(root, *, use_symlink: bool | None = None) -> list[str]:
+    """Write one set of project rules both agents read.
+
+    ``AGENTS.md`` gets a marked llm-router block (Codex reads AGENTS.md).
+    ``CLAUDE.md`` becomes a symlink to it (Claude Code reads CLAUDE.md), or a
+    copy on Windows. An existing CLAUDE.md that is a real file is kept and gets
+    the same marked block appended -- a user's file is never replaced by a
+    link. Re-runs replace the block in place.
+    """
+    import os
+    import pathlib
+
+    from llm_router import codex_host, install_manifest
+    from llm_router.install_hooks import _localized_rules_text
+
+    root = pathlib.Path(root)
+    actions: list[str] = []
+    template = pathlib.Path(__file__).parent.parent / "rules" / "project-agents.md"
+    if not template.exists():
+        return [f"  rules template missing: {template}"]
+    body = _localized_rules_text(template)
+    if use_symlink is None:
+        use_symlink = os.name != "nt"
+
+    agents = root / "AGENTS.md"
+    existing = agents.read_text() if agents.exists() else ""
+    updated = codex_host.upsert_marked_block(existing, body)
+    if updated != existing:
+        agents.write_text(updated)
+        actions.append(f"✓ {'Updated' if existing else 'Created'} {agents}")
+    else:
+        actions.append(f"  {agents} already current (skipped)")
+    install_manifest.record("codex_agents_block", agents)
+
+    claude = root / "CLAUDE.md"
+    if claude.is_symlink():
+        try:
+            target = (claude.parent / os.readlink(claude)).resolve()
+        except OSError:
+            target = None
+        if target == agents.resolve():
+            actions.append(f"  {claude} already links to AGENTS.md (skipped)")
+        else:
+            actions.append(f"  {claude} is a link elsewhere — left alone")
+    elif claude.exists():
+        text = claude.read_text()
+        new_text = codex_host.upsert_marked_block(text, body)
+        if new_text != text:
+            claude.write_text(new_text)
+            actions.append(f"✓ Added the rules block to existing {claude} (kept as a file)")
+        else:
+            actions.append(f"  {claude} already current (skipped)")
+        install_manifest.record("codex_agents_block", claude)
+    elif use_symlink:
+        claude.symlink_to("AGENTS.md")
+        # Not kind "file": record() resolves an existing path, and resolving
+        # the link yields AGENTS.md -- uninstall would then delete the user's
+        # rules file instead of our link.
+        install_manifest.record("claude_link", agents, link=str(claude.absolute()))
+        actions.append(f"✓ Linked {claude} -> AGENTS.md")
+    else:
+        claude.write_text(updated)
+        install_manifest.record("codex_agents_block", claude)
+        actions.append(f"✓ Copied the rules into {claude} (symlinks unavailable here)")
     return actions
 
 

--- a/src/llm_router/install_manifest.py
+++ b/src/llm_router/install_manifest.py
@@ -34,6 +34,7 @@ install, and a single removal failure must never abort uninstall.
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 from typing import Any
 
@@ -199,6 +200,8 @@ def apply_uninstall() -> list[str]:
                 actions += _remove_codex_hooks(path)
             elif kind == "codex_agents_block":
                 actions += _remove_codex_agents_block(path)
+            elif kind == "claude_link":
+                actions += _remove_claude_link(pathlib.Path(rec.get("link", "")), path)
         except Exception as e:  # noqa: BLE001 — one bad record must not abort the rest
             _p = rec.get("path", "?")
             actions.append(f"  manifest removal skipped ({_p}): {e}")
@@ -300,3 +303,18 @@ def _remove_codex_agents_block(path: pathlib.Path) -> list[str]:
     else:
         path.unlink()
     return [f"✓ Removed llm_router block from {path}"]
+
+
+def _remove_claude_link(link: pathlib.Path, target: pathlib.Path) -> list[str]:
+    """Remove the CLAUDE.md symlink we created, only while it still points at
+    the AGENTS.md we recorded. A file or a re-pointed link is the user's."""
+    if not str(link) or not link.is_symlink():
+        return []
+    try:
+        points_at = (link.parent / os.readlink(link)).resolve()
+    except OSError:
+        return []
+    if points_at != pathlib.Path(target).resolve():
+        return []
+    link.unlink()
+    return [f"✓ Removed link {link}"]

--- a/src/llm_router/rules/project-agents.md
+++ b/src/llm_router/rules/project-agents.md
@@ -1,0 +1,21 @@
+<!-- llm_router-rules-version: 1 -->
+## LLM Router — routing rules for this repository
+
+This repository is worked on with **LLM Router** installed in the agent host
+(Claude Code, Codex CLI, or both). Before answering, route the *thinking* to the
+cheapest model that can do it; use your own file and shell tools as usual.
+
+| Task | Call | Typically served by |
+|---|---|---|
+| Simple question, lookup, one-liner | `llm_query` | local Ollama / the free seat |
+| Deep analysis, review, design trade-off | `llm_analyze` | the subscription seat |
+| Code generation or refactor | `llm_code` | coder model / Codex |
+| Research, current events | `llm_research` | web-grounded model |
+| Writing, docs, content | `llm_generate` | fast cloud model |
+
+- If a `⚡ ROUTE:` hint is in your context, follow it: call the named tool and
+  use its result. If the result is weak or the model refuses, do the work yourself.
+- Never invent a routed answer. Route with `context=…` when the task needs files
+  from this repository, or handle it directly.
+- Seats already paid for (Claude, ChatGPT, Google) are the free tier; API keys are
+  used only for a tier no seat covers.

--- a/tests/test_install_project.py
+++ b/tests/test_install_project.py
@@ -1,0 +1,100 @@
+"""`llm-router install --project`: one rules file both agents read."""
+from __future__ import annotations
+
+import os
+import pathlib
+
+import pytest
+
+from llm_router import codex_host, install_manifest
+from llm_router.commands import install
+
+
+@pytest.fixture
+def home(monkeypatch, tmp_path):
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: h))
+    monkeypatch.setenv("HOME", str(h))
+    return h
+
+
+def _block_count(path):
+    return path.read_text().count(codex_host.AGENTS_BLOCK_START)
+
+
+def test_fresh_repo_gets_agents_md_and_a_relative_claude_link(home, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    actions = install._install_project_files(repo)
+    agents, claude = repo / "AGENTS.md", repo / "CLAUDE.md"
+    assert _block_count(agents) == 1
+    assert "llm_query" in agents.read_text() or "llm(" in agents.read_text()
+    assert claude.is_symlink() and os.readlink(claude) == "AGENTS.md"
+    assert claude.read_text() == agents.read_text()
+    assert any("Created" in a for a in actions) and any("Linked" in a for a in actions)
+
+
+def test_existing_agents_md_is_preserved_and_rerun_is_idempotent(home, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "AGENTS.md").write_text("# Team conventions\n\nUse uv.\n")
+    install._install_project_files(repo)
+    text = (repo / "AGENTS.md").read_text()
+    assert text.startswith("# Team conventions\n\nUse uv.\n")
+    assert _block_count(repo / "AGENTS.md") == 1
+    actions = install._install_project_files(repo)
+    assert _block_count(repo / "AGENTS.md") == 1
+    assert (repo / "AGENTS.md").read_text() == text
+    assert all("skipped" in a for a in actions)
+
+
+def test_existing_claude_md_file_is_kept_and_gets_the_block(home, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "CLAUDE.md").write_text("# Claude notes\n")
+    install._install_project_files(repo)
+    claude = repo / "CLAUDE.md"
+    assert not claude.is_symlink()
+    assert claude.read_text().startswith("# Claude notes\n")
+    assert _block_count(claude) == 1
+    assert _block_count(repo / "AGENTS.md") == 1
+
+
+def test_foreign_claude_link_is_left_alone(home, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "other.md").write_text("x\n")
+    (repo / "CLAUDE.md").symlink_to("other.md")
+    actions = install._install_project_files(repo)
+    assert os.readlink(repo / "CLAUDE.md") == "other.md"
+    assert any("left alone" in a for a in actions)
+
+
+def test_windows_copies_instead_of_linking(home, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    install._install_project_files(repo, use_symlink=False)
+    claude = repo / "CLAUDE.md"
+    assert not claude.is_symlink()
+    assert claude.read_text() == (repo / "AGENTS.md").read_text()
+
+
+def test_uninstall_removes_the_block_and_our_link_only(home, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "AGENTS.md").write_text("# mine\n")
+    install._install_project_files(repo)
+    install_manifest.apply_uninstall()
+    assert (repo / "AGENTS.md").read_text() == "# mine\n"
+    assert not (repo / "CLAUDE.md").exists() and not (repo / "CLAUDE.md").is_symlink()
+
+
+def test_run_install_project_flag_uses_cwd_and_touches_nothing_global(home, tmp_path, monkeypatch, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    install._run_install(["--project"])
+    assert (repo / "AGENTS.md").exists() and (repo / "CLAUDE.md").is_symlink()
+    assert not (home / ".claude").exists() and not (home / ".codex").exists()
+    assert "AGENTS.md" in capsys.readouterr().out


### PR DESCRIPTION
PR 4 of 4 from `guide/PLAN_DUAL_HOST_INSTALL.md`. Stacked on #130.

`llm-router install --project` writes a marked llm-router block into the repository's `AGENTS.md` (Codex reads it) and links `CLAUDE.md` to it (Claude Code reads it). A copy on Windows. An existing `CLAUDE.md` file is kept and gets the same block; a link pointing elsewhere is left alone. Re-runs replace the block in place; uninstall removes the block and our link only.

The link gets its own manifest kind: `record()` resolves an existing path, and resolving the symlink yields `AGENTS.md`, so a plain `file` record would have made uninstall delete the user's rules file.

Template: `src/llm_router/rules/project-agents.md`, host-neutral, tool names localized to the active surface.

**Tests.** 7 new. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LktEjGmgYMKstVfPC7NGtt